### PR TITLE
feat: improve card visibility and theme support

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,9 +9,20 @@ class App extends StatelessWidget {
     return MaterialApp(
       title: 'Touch NoteBook',
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.light,
+        ),
         useMaterial3: true,
       ),
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.deepPurple,
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      ),
+      themeMode: ThemeMode.system,
       home: const HomeScreen(),
     );
   }

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -311,7 +311,8 @@ class _ContactCardState extends State<_ContactCard> {
       duration: const Duration(milliseconds: 100),
       child: Material(
         borderRadius: border,
-        color: Theme.of(context).colorScheme.surface,
+        color: Theme.of(context).colorScheme.surfaceVariant,
+        elevation: 2,
         child: InkWell(
           borderRadius: border,
           onTap: () {},

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -216,8 +216,9 @@ class _CategoryCardState extends State<_CategoryCard> {
       scale: _pressed ? 0.98 : 1.0,
       duration: const Duration(milliseconds: 100),
       child: Material(
-        color: Theme.of(context).colorScheme.surface,
+        color: Theme.of(context).colorScheme.surfaceVariant,
         borderRadius: borderRadius,
+        elevation: 2,
         child: InkWell(
           borderRadius: borderRadius,
           onTap: widget.onTap,


### PR DESCRIPTION
## Summary
- add background contrast and elevation to contact cards
- add background contrast and elevation to category cards
- support light and dark themes based on system setting

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab85eb96e483268c3a1054f1668e1d