### PR TITLE
Add contact deletion and sort new contacts first

### DIFF
--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -24,7 +24,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
   final TextEditingController _searchController = TextEditingController();
   Timer? _debounce;
   String _query = '';
-  SortOption _sort = SortOption.nameAsc;
+  SortOption _sort = SortOption.dateDesc;
   Set<String> _statusFilters = {};
 
   List<Contact> _all = [];
@@ -260,7 +260,28 @@ class _ContactListScreenState extends State<ContactListScreen> {
               const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               itemBuilder: (context, index) {
                 final c = contacts[index];
-                return _ContactCard(contact: c);
+                return Dismissible(
+                  key: ValueKey(c.id),
+                  direction: DismissDirection.endToStart,
+                  background: Container(
+                    alignment: Alignment.centerRight,
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    color: Colors.red,
+                    child: const Icon(Icons.delete, color: Colors.white),
+                  ),
+                  onDismissed: (_) async {
+                    if (c.id != null) {
+                      await ContactDatabase.instance.delete(c.id!);
+                      setState(() {
+                        _all.removeWhere((e) => e.id == c.id);
+                      });
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Контакт удалён')),
+                      );
+                    }
+                  },
+                  child: _ContactCard(contact: c),
+                );
               },
               separatorBuilder: (_, __) => const SizedBox(height: 8),
               itemCount: contacts.length,

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -46,9 +46,18 @@ class ContactDatabase {
 
   Future<List<Contact>> contactsByCategory(String category) async {
     final db = await database;
-    final maps =
-        await db.query('contacts', where: 'category = ?', whereArgs: [category]);
+    final maps = await db.query(
+      'contacts',
+      where: 'category = ?',
+      whereArgs: [category],
+      orderBy: 'createdAt DESC',
+    );
     return maps.map((e) => Contact.fromMap(e)).toList();
+  }
+
+  Future<int> delete(int id) async {
+    final db = await database;
+    return await db.delete('contacts', where: 'id = ?', whereArgs: [id]);
   }
 
   Future<int> countByCategory(String category) async {


### PR DESCRIPTION
## Summary
- Display newest contacts first and default to date-based sorting
- Allow removing contact cards via swipe and database delete

## Testing
- `dart format lib/services/contact_database.dart lib/screens/contact_list_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab905b6f9c8326b44f506b2f4f4923