### PR TITLE
Add long-press contact deletion with confirmation

### DIFF
--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -24,7 +24,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
   final TextEditingController _searchController = TextEditingController();
   Timer? _debounce;
   String _query = '';
-  SortOption _sort = SortOption.nameAsc;
+  SortOption _sort = SortOption.dateDesc;
   Set<String> _statusFilters = {};
 
   List<Contact> _all = [];
@@ -138,6 +138,56 @@ class _ContactListScreenState extends State<ContactListScreen> {
     );
     if (result != null) {
       setState(() => _statusFilters = result);
+    }
+  }
+
+  Future<void> _showContactMenu(Contact c) async {
+    final action = await showModalBottomSheet<String>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.delete),
+                title: const Text('Удалить'),
+                onTap: () => Navigator.pop(context, 'delete'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    if (action == 'delete') {
+      final confirm = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Удалить контакт?'),
+          content: const Text('Это действие нельзя отменить.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Отмена'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Удалить'),
+            ),
+          ],
+        ),
+      );
+      if (confirm == true && c.id != null) {
+        await ContactDatabase.instance.delete(c.id!);
+        setState(() {
+          _all.removeWhere((e) => e.id == c.id);
+        });
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Контакт удалён')),
+          );
+        }
+      }
     }
   }
 
@@ -256,15 +306,18 @@ class _ContactListScreenState extends State<ContactListScreen> {
               ),
             )
                 : ListView.separated(
-              padding:
-              const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              itemBuilder: (context, index) {
-                final c = contacts[index];
-                return _ContactCard(contact: c);
-              },
-              separatorBuilder: (_, __) => const SizedBox(height: 8),
-              itemCount: contacts.length,
-            ),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    itemBuilder: (context, index) {
+                      final c = contacts[index];
+                      return _ContactCard(
+                        contact: c,
+                        onLongPress: () => _showContactMenu(c),
+                      );
+                    },
+                    separatorBuilder: (_, __) => const SizedBox(height: 8),
+                    itemCount: contacts.length,
+                  ),
           ),
         ],
       ),
@@ -294,7 +347,8 @@ class _ContactListScreenState extends State<ContactListScreen> {
 
 class _ContactCard extends StatefulWidget {
   final Contact contact;
-  const _ContactCard({required this.contact});
+  final VoidCallback? onLongPress;
+  const _ContactCard({required this.contact, this.onLongPress});
 
   @override
   State<_ContactCard> createState() => _ContactCardState();
@@ -318,6 +372,10 @@ class _ContactCardState extends State<_ContactCard> {
         child: InkWell(
           borderRadius: border,
           onTap: () {},
+          onLongPress: () {
+            _set(false);
+            widget.onLongPress?.call();
+          },
           onTapDown: (_) => _set(true),
           onTapCancel: () => _set(false),
           onTapUp: (_) => _set(false),

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -46,9 +46,18 @@ class ContactDatabase {
 
   Future<List<Contact>> contactsByCategory(String category) async {
     final db = await database;
-    final maps =
-        await db.query('contacts', where: 'category = ?', whereArgs: [category]);
+    final maps = await db.query(
+      'contacts',
+      where: 'category = ?',
+      whereArgs: [category],
+      orderBy: 'createdAt DESC',
+    );
     return maps.map((e) => Contact.fromMap(e)).toList();
+  }
+
+  Future<int> delete(int id) async {
+    final db = await database;
+    return await db.delete('contacts', where: 'id = ?', whereArgs: [id]);
   }
 
   Future<int> countByCategory(String category) async {


### PR DESCRIPTION
## Summary
- Display newest contacts first and default to date-based sorting
- Open a delete option via long-press menu with confirmation before removing contacts

## Testing
- `dart format lib/screens/contact_list_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab905b6f9c8326b44f506b2f4f4923