### PR TITLE
Fix snackbar persistence on contact deletion

### DIFF
--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -207,6 +207,9 @@ class _ContactListScreenState extends State<ContactListScreen> {
         action: SnackBarAction(
           label: 'Отменить',
           onPressed: () async {
+            // Hide snackbar immediately after pressing undo to avoid it
+            // lingering on screen while the contact is restored.
+            messenger.hideCurrentSnackBar();
             // Пытаемся вернуть с прежним id.
             try {
               final newRowId = await ContactDatabase.instance.insert(c);


### PR DESCRIPTION
## Summary
- hide snackbar immediately when undoing a contact deletion to prevent lingering snackbar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab976216b883268f55757ece46a5f8