### PR TITLE
Fix snackbar timer persistence

### DIFF
--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -23,6 +23,7 @@ class ContactListScreen extends StatefulWidget {
 class _ContactListScreenState extends State<ContactListScreen> {
   final TextEditingController _searchController = TextEditingController();
   Timer? _debounce;
+  Timer? _snackTimer;
   String _query = '';
   SortOption _sort = SortOption.dateDesc;
   Set<String> _statusFilters = {};
@@ -44,6 +45,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
   @override
   void dispose() {
     _debounce?.cancel();
+    _snackTimer?.cancel();
     _searchController.dispose();
     super.dispose();
   }
@@ -200,13 +202,17 @@ class _ContactListScreenState extends State<ContactListScreen> {
     const duration = Duration(seconds: 4);
 
     messenger.clearSnackBars();
-    messenger.showSnackBar(
+    _snackTimer?.cancel();
+    final controller = messenger.showSnackBar(
       SnackBar(
-        duration: duration,
+        // Контролируем длительность вручную, чтобы таймер не сбрасывался
+        // при переходах и перестройках.
+        duration: const Duration(days: 1),
         content: _UndoSnackContent(duration: duration),
         action: SnackBarAction(
           label: 'Отменить',
           onPressed: () async {
+            _snackTimer?.cancel();
             // Hide snackbar immediately after pressing undo to avoid it
             // lingering on screen while the contact is restored.
             messenger.hideCurrentSnackBar();
@@ -220,7 +226,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
             } catch (_) {
               // На случай конфликта id — вставляем без id (сгенерируется новый)
               final newId =
-              await ContactDatabase.instance.insert(c.copyWith(id: null));
+                  await ContactDatabase.instance.insert(c.copyWith(id: null));
               setState(() {
                 _all.add(c.copyWith(id: newId));
               });
@@ -229,6 +235,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
         ),
       ),
     );
+    _snackTimer = Timer(duration, () => controller.close());
   }
 
   List<Contact> get _filtered {
@@ -572,33 +579,62 @@ class _ContactCardState extends State<_ContactCard> {
 
 /// Контент SnackBar с обратным отсчётом и прогресс-баром,
 /// синхронизированным с duration самого SnackBar.
-class _UndoSnackContent extends StatelessWidget {
+class _UndoSnackContent extends StatefulWidget {
   final Duration duration;
   const _UndoSnackContent({required this.duration});
 
   @override
+  State<_UndoSnackContent> createState() => _UndoSnackContentState();
+}
+
+class _UndoSnackContentState extends State<_UndoSnackContent> {
+  late final DateTime _start;
+  late Timer _ticker;
+  double _value = 1.0;
+
+  @override
+  void initState() {
+    super.initState();
+    _start = DateTime.now();
+    _ticker = Timer.periodic(const Duration(milliseconds: 100), (timer) {
+      final elapsed = DateTime.now().difference(_start);
+      final remaining = widget.duration - elapsed;
+      if (!mounted) return;
+      if (remaining <= Duration.zero) {
+        setState(() => _value = 0);
+        _ticker.cancel();
+      } else {
+        setState(() {
+          _value =
+              remaining.inMilliseconds / widget.duration.inMilliseconds;
+        });
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker.cancel();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return TweenAnimationBuilder<double>(
-      tween: Tween(begin: 1.0, end: 0.0),
-      duration: duration,
-      builder: (context, value, _) {
-        final secondsLeft =
-        ((value * duration.inMilliseconds) / 1000).ceil().clamp(0, 999);
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
+    final secondsLeft =
+        (_value * widget.duration.inSeconds).ceil().clamp(0, 999);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
           children: [
-            Row(
-              children: [
-                const Expanded(child: Text('Контакт удалён')),
-                Text('$secondsLeft c'),
-              ],
-            ),
-            const SizedBox(height: 4),
-            LinearProgressIndicator(value: value),
+            const Expanded(child: Text('Контакт удалён')),
+            Text('$secondsLeft c'),
           ],
-        );
-      },
+        ),
+        const SizedBox(height: 4),
+        LinearProgressIndicator(value: _value),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- ensure delete snackbar auto-dismisses and timer does not reset across rebuilds or navigation
- convert undo snackbar content to stateful widget with real-time countdown

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9fbe2cc08326b3a404206d811b55