### PR TITLE
Enable Russian localization and update date pickers

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 // lib/app.dart
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'screens/home_screen.dart';
 
 class App extends StatelessWidget {
@@ -30,6 +31,16 @@ class App extends StatelessWidget {
         useMaterial3: true,
       ),
       themeMode: ThemeMode.system,
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('ru'),
+        Locale('en'),
+      ],
+      locale: const Locale('ru'),
       home: const HomeScreen(),
     );
   }

--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -75,6 +75,22 @@ class _AddContactScreenState extends State<AddContactScreen> {
     return age;
   }
 
+  String _formatAge(int age) {
+    final lastTwo = age % 100;
+    final last = age % 10;
+    String suffix;
+    if (lastTwo >= 11 && lastTwo <= 14) {
+      suffix = 'лет';
+    } else if (last == 1) {
+      suffix = 'год';
+    } else if (last >= 2 && last <= 4) {
+      suffix = 'года';
+    } else {
+      suffix = 'лет';
+    }
+    return '$age $suffix';
+  }
+
   Future<void> _pickBirthOrAge() async {
     final choice = await showModalBottomSheet<String>(
       context: context,
@@ -102,13 +118,14 @@ class _AddContactScreenState extends State<AddContactScreen> {
         firstDate: DateTime(1900),
         lastDate: now,
         initialDate: now,
+        locale: const Locale('ru'),
       );
       if (picked != null) {
         _birthDate = picked;
         _ageManual = null;
         final age = _calcAge(picked);
         _birthController.text =
-        '${DateFormat('dd.MM.yyyy').format(picked)} ($age лет)';
+        '${DateFormat('dd.MM.yyyy').format(picked)} (${_formatAge(age)})';
       }
     } else if (choice == 'age') {
       final ctrl = TextEditingController();
@@ -137,7 +154,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       if (age != null) {
         _ageManual = age;
         _birthDate = null;
-        _birthController.text = 'Возраст: $age';
+        _birthController.text = 'Возраст: ${_formatAge(age)}';
       }
     }
     setState(() {});
@@ -274,6 +291,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       firstDate: DateTime(1900),
       lastDate: now,
       initialDate: _addedDate,
+      locale: const Locale('ru'),
     );
     if (picked != null) {
       setState(() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add flutter_localizations dependency
- configure Russian localization in MaterialApp
- show date pickers in Russian and fix age hint
- inflect Russian age suffix correctly

## Testing
- `dart format lib/screens/add_contact_screen.dart` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abb90cea108326865bd37233ec390f