### PR TITLE
feat: integrate notes list and details access

### DIFF
--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -1,0 +1,29 @@
+class Note {
+  final int? id;
+  final int contactId;
+  final String text;
+  final DateTime createdAt;
+
+  Note({this.id, required this.contactId, required this.text, required this.createdAt});
+
+  Note copyWith({int? id}) => Note(
+        id: id ?? this.id,
+        contactId: contactId,
+        text: text,
+        createdAt: createdAt,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'contactId': contactId,
+        'text': text,
+        'createdAt': createdAt.millisecondsSinceEpoch,
+      };
+
+  factory Note.fromMap(Map<String, dynamic> map) => Note(
+        id: map['id'] as int?,
+        contactId: map['contactId'] as int,
+        text: map['text'] as String,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+      );
+}

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -7,8 +7,10 @@ import 'package:characters/characters.dart';
 
 import '../app.dart'; // для App.navigatorKey (SnackBar после pop)
 import '../models/contact.dart';
+import '../models/note.dart';
 import '../services/contact_database.dart';
 import 'contact_list_screen.dart'; // переход к восстановленному контакту
+import 'notes_list_screen.dart';
 
 class ContactDetailsScreen extends StatefulWidget {
   final Contact contact;
@@ -275,6 +277,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   bool _extraExpanded = false; // «Дополнительно»
   bool _notesExpanded = false; // «Заметки»
+  List<Note> _notes = [];
 
   // FocusNodes — для подсветки «плиток»
   final FocusNode _focusBirth = FocusNode(skipTraversal: true);
@@ -318,6 +321,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     super.initState();
     _contact = widget.contact;
     _loadFromContact();
+    _loadNotes();
   }
 
   @override
@@ -341,6 +345,37 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     _focusStatus.dispose();
     _focusAdded.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadNotes() async {
+    if (_contact.id == null) return;
+    final notes = await ContactDatabase.instance.lastNotesByContact(_contact.id!, limit: 3);
+    if (mounted) setState(() => _notes = notes);
+  }
+
+  Future<void> _addNote() async {
+    final controller = TextEditingController();
+    final text = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Новая заметка'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          maxLines: null,
+          decoration: const InputDecoration(labelText: 'Заметка'),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Отмена')),
+          TextButton(onPressed: () => Navigator.pop(context, controller.text.trim()), child: const Text('Сохранить')),
+        ],
+      ),
+    );
+    if (text != null && text.isNotEmpty && _contact.id != null) {
+      await ContactDatabase.instance
+          .insertNote(Note(contactId: _contact.id!, text: text, createdAt: DateTime.now()));
+      await _loadNotes();
+    }
   }
 
   // ==================== helpers ====================
@@ -1221,13 +1256,35 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     if (v) _scrollToCard(_notesCardKey);
                   },
                   headerActions: [
-                    TextButton(onPressed: () {/* TODO: добавить заметку */}, child: const Text('Добавить')),
+                    TextButton(onPressed: _addNote, child: const Text('Добавить')),
                     const SizedBox(width: 8),
-                    TextButton(onPressed: () {/* TODO: все заметки */}, child: const Text('Все')),
+                    TextButton(
+                        onPressed: () async {
+                          if (_contact.id == null) return;
+                          await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (_) => NotesListScreen(contact: _contact)),
+                          );
+                          await _loadNotes();
+                        },
+                        child: const Text('Все')),
                   ],
-                  children: const [
-                    Card(elevation: 0, child: ListTile(title: Text('Нет заметок'))),
-                  ],
+                  children: _notes.isEmpty
+                      ? const [
+                          Card(elevation: 0, child: ListTile(title: Text('Нет заметок'))),
+                        ]
+                      : _notes
+                          .map(
+                            (n) => Card(
+                              elevation: 0,
+                              child: ListTile(
+                                title: Text(n.text),
+                                subtitle: Text(DateFormat('dd.MM.yyyy HH:mm').format(n.createdAt)),
+                              ),
+                            ),
+                          )
+                          .toList(),
                 ),
               ),
 

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -251,6 +251,11 @@ class _ContactListScreenState extends State<ContactListScreen> {
             mainAxisSize: MainAxisSize.min,
             children: [
               ListTile(
+                leading: const Icon(Icons.info_outline),
+                title: const Text('Детали контакта'),
+                onTap: () => Navigator.pop(context, 'details'),
+              ),
+              ListTile(
                 leading: const Icon(Icons.delete),
                 title: const Text('Удалить'),
                 onTap: () => Navigator.pop(context, 'delete'),
@@ -260,7 +265,13 @@ class _ContactListScreenState extends State<ContactListScreen> {
         );
       },
     );
-    if (action == 'delete') {
+    if (action == 'details') {
+      await Navigator.push(
+        context,
+        MaterialPageRoute(builder: (context) => ContactDetailsScreen(contact: c)),
+      );
+      await _loadContacts();
+    } else if (action == 'delete') {
       final confirm = await showDialog<bool>(
         context: context,
         builder: (context) => AlertDialog(


### PR DESCRIPTION
## Summary
- add Note model and storage
- show recent notes and full list for contacts
- extend contact menu with details shortcut

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acd186e62083268e7b661aa8cd4737