### PR TITLE
Add pagination and update picker fields

### DIFF
--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -136,6 +136,23 @@ class ContactDatabase {
     return maps.map(Contact.fromMap).toList();
   }
 
+  Future<List<Contact>> contactsByCategoryPaged(
+    String category, {
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final db = await database;
+    final maps = await db.query(
+      'contacts',
+      where: 'category = ?',
+      whereArgs: [category],
+      orderBy: 'createdAt DESC',
+      limit: limit,
+      offset: offset,
+    );
+    return maps.map(Contact.fromMap).toList();
+  }
+
   Future<int> update(Contact contact) async {
     final db = await database;
     final rows = await db.update(
@@ -199,6 +216,23 @@ class ContactDatabase {
       where: 'contactId = ?',
       whereArgs: [contactId],
       orderBy: 'createdAt DESC',
+    );
+    return maps.map(Note.fromMap).toList();
+  }
+
+  Future<List<Note>> notesByContactPaged(
+    int contactId, {
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final db = await database;
+    final maps = await db.query(
+      'notes',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'createdAt DESC',
+      limit: limit,
+      offset: offset,
     );
     return maps.map(Note.fromMap).toList();
   }


### PR DESCRIPTION
## Summary
- add paged queries for contacts and notes
- implement lazy loading pagination on contact and note lists
- replace picker tiles with read-only text fields that show floating hints

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeacc81ac8832683c2ac0e852e8c6f