### PR TITLE
Move note deletion to bottom button

### DIFF
--- a/lib/screens/note_details_screen.dart
+++ b/lib/screens/note_details_screen.dart
@@ -238,12 +238,6 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
               tooltip: 'Сохранить',
               icon: const Icon(Icons.check),
               onPressed: _canSave ? _save : null,
-            )
-          else
-            IconButton(
-              tooltip: 'Удалить',
-              icon: const Icon(Icons.delete_outline),
-              onPressed: _delete,
             ),
         ],
       ),
@@ -298,20 +292,17 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
           ),
         ),
       ),
-      // 🔻 нижняя кнопка теперь ТОЛЬКО в режиме редактирования
-      bottomNavigationBar: _isEditing
-          ? Padding(
+      bottomNavigationBar: Padding(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        child: FilledButton.icon(
-          onPressed: _canSave ? _save : null,
-          icon: const Icon(Icons.check),
-          label: const Text('Сохранить'),
-          style: FilledButton.styleFrom(
-            padding: const EdgeInsets.symmetric(vertical: 14),
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.red,
+            foregroundColor: Colors.white,
           ),
+          onPressed: _delete,
+          child: const Text('Удалить заметку'),
         ),
-      )
-          : null,
+      ),
 
     );
   }


### PR DESCRIPTION
## Summary
- move note deletion to bottom button and remove app bar delete icon

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b000a8c1e08326b01753aaeb80c20a