### PR TITLE
Move note deletion to bottom button

### DIFF
--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -698,14 +698,15 @@ class _AddContactScreenState extends State<AddContactScreen> {
   // ==================== UI helpers ====================
 
   InputDecoration _outlinedDec(
-      ThemeData theme, {
-        required String label,
-        IconData? prefixIcon,
-        String? hint,
-        required TextEditingController controller,
-        Widget? suffixIcon,
-        bool showClear = true,
-      }) {
+    ThemeData theme, {
+    required String label,
+    IconData? prefixIcon,
+    String? hint,
+    required TextEditingController controller,
+    Widget? suffixIcon,
+    bool showClear = true,
+    bool requiredField = false,
+  }) {
     Widget? suffix = suffixIcon;
     if (showClear && controller.text.isNotEmpty) {
       suffix = IconButton(
@@ -722,6 +723,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       hintText: hint,
       prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
       suffixIcon: suffix,
+      helperText: requiredField ? 'Обязательное поле' : 'Необязательное поле',
       border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
       enabledBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(12),
@@ -730,7 +732,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       filled: false,
       isDense: true,
       contentPadding:
-      const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+          const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
     );
   }
 
@@ -815,6 +817,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
     required bool isOpen,
     required FocusNode focusNode,
     required VoidCallback onTap,
+    bool requiredField = false,
   }) {
     return TextFormField(
       key: key,
@@ -829,6 +832,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
         controller: controller,
         suffixIcon: Icon(isOpen ? Icons.arrow_drop_up : Icons.arrow_drop_down),
         showClear: false,
+        requiredField: requiredField,
       ),
       onTap: () {
         FocusScope.of(context).requestFocus(focusNode);
@@ -942,6 +946,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                         label: 'ФИО*',
                         prefixIcon: Icons.person_outline,
                         controller: _nameController,
+                        requiredField: true,
                       ),
                       validator: (v) => v == null || v.trim().isEmpty ? 'Введите ФИО' : null,
                       onTapOutside: (_) => _defocus(),
@@ -962,6 +967,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                         label: 'Телефон*',
                         prefixIcon: Icons.phone_outlined,
                         controller: _phoneController,
+                        requiredField: true,
                       ),
                       validator: (v) => _phoneValid ? null : 'Введите телефон',
                       onTapOutside: (_) => _defocus(),
@@ -983,6 +989,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                     isOpen: _categoryOpen,
                     focusNode: _focusCategory,
                     onTap: _pickCategory,
+                    requiredField: true,
                   ),
                   const SizedBox(height: 12),
                   _pickerField(
@@ -1000,6 +1007,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                         _hintSelectCategory();
                       }
                     },
+                    requiredField: true,
                   ),
                 ],
               ),

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -838,14 +838,15 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   // ==================== UI helpers ====================
 
   InputDecoration _outlinedDec(
-      ThemeData theme, {
-        required String label,
-        IconData? prefixIcon,
-        String? hint,
-        required TextEditingController controller,
-        Widget? suffixIcon,
-        bool showClear = true,
-      }) {
+    ThemeData theme, {
+    required String label,
+    IconData? prefixIcon,
+    String? hint,
+    required TextEditingController controller,
+    Widget? suffixIcon,
+    bool showClear = true,
+    bool requiredField = false,
+  }) {
     return InputDecoration(
       labelText: label,
       hintText: hint,
@@ -853,14 +854,15 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       suffixIcon: suffixIcon ??
           (showClear && controller.text.isNotEmpty
               ? IconButton(
-            tooltip: 'Очистить',
-            icon: const Icon(Icons.close),
-            onPressed: () {
-              controller.clear();
-              setState(_updateEditingFromDirty);
-            },
-          )
+                  tooltip: 'Очистить',
+                  icon: const Icon(Icons.close),
+                  onPressed: () {
+                    controller.clear();
+                    setState(_updateEditingFromDirty);
+                  },
+                )
               : null),
+      helperText: requiredField ? 'Обязательное поле' : 'Необязательное поле',
       border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
       enabledBorder: OutlineInputBorder(
         borderRadius: BorderRadius.circular(12),
@@ -971,6 +973,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     required bool isOpen,
     required FocusNode focusNode,
     required VoidCallback onTap,
+    bool requiredField = false,
   }) {
     return TextFormField(
       key: key,
@@ -985,6 +988,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
         controller: controller,
         suffixIcon: Icon(isOpen ? Icons.arrow_drop_up : Icons.arrow_drop_down),
         showClear: false,
+        requiredField: requiredField,
       ),
       onTap: () {
         FocusScope.of(context).requestFocus(focusNode);
@@ -1107,6 +1111,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                         label: 'ФИО*',
                         prefixIcon: Icons.person_outline,
                         controller: _nameController,
+                        requiredField: true,
                       ),
                       validator: (v) => v == null || v.trim().isEmpty ? 'Введите ФИО' : null,
                       onTapOutside: (_) => _defocus(),
@@ -1128,6 +1133,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                         label: 'Телефон*',
                         prefixIcon: Icons.phone_outlined,
                         controller: _phoneController,
+                        requiredField: true,
                       ),
                       validator: (v) => _phoneValid ? null : 'Введите телефон',
                       onTapOutside: (_) => _defocus(),
@@ -1150,6 +1156,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     isOpen: _categoryOpen,
                     focusNode: _focusCategory,
                     onTap: _pickCategory,
+                    requiredField: true,
                   ),
                   const SizedBox(height: 12),
                   _pickerField(
@@ -1161,6 +1168,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     isOpen: _statusOpen,
                     focusNode: _focusStatus,
                     onTap: _pickStatus,
+                    requiredField: true,
                   ),
                 ],
               ),
@@ -1298,23 +1306,34 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                   ],
                   children: _notes.isEmpty
                       ? const [
-                    Card(elevation: 0, child: ListTile(title: Text('Нет заметок'))),
-                  ]
+                          Card(
+                            elevation: 0,
+                            child: ListTile(
+                              leading: Icon(Icons.sticky_note_2_outlined),
+                              title: Text('Нет заметок'),
+                            ),
+                          ),
+                        ]
                       : [
-                    Card(
-                      elevation: 0,
-                      child: Column(
-                        children: ListTile.divideTiles(
-                          context: context,
-                          tiles: _notes.map((n) => ListTile(
-                            title: Text(n.text, maxLines: 2, overflow: TextOverflow.ellipsis),
-                            subtitle: Text(DateFormat('dd.MM.yyyy').format(n.createdAt)),
-                            onTap: () => _openNote(n),
-                          )),
-                        ).toList(),
-                      ),
-                    ),
-                  ],
+                          Card(
+                            elevation: 0,
+                            child: Column(
+                              children: ListTile.divideTiles(
+                                context: context,
+                                tiles: _notes.map((n) => ListTile(
+                                      leading:
+                                          const Icon(Icons.sticky_note_2_outlined),
+                                      title: Text(n.text,
+                                          maxLines: 2,
+                                          overflow: TextOverflow.ellipsis),
+                                      subtitle: Text(DateFormat('dd.MM.yyyy')
+                                          .format(n.createdAt)),
+                                      onTap: () => _openNote(n),
+                                    )),
+                              ).toList(),
+                            ),
+                          ),
+                        ],
                 ),
               ),
 

--- a/lib/screens/note_details_screen.dart
+++ b/lib/screens/note_details_screen.dart
@@ -238,12 +238,6 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
               tooltip: 'Сохранить',
               icon: const Icon(Icons.check),
               onPressed: _canSave ? _save : null,
-            )
-          else
-            IconButton(
-              tooltip: 'Удалить',
-              icon: const Icon(Icons.delete_outline),
-              onPressed: _delete,
             ),
         ],
       ),
@@ -298,20 +292,17 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
           ),
         ),
       ),
-      // 🔻 нижняя кнопка теперь ТОЛЬКО в режиме редактирования
-      bottomNavigationBar: _isEditing
-          ? Padding(
+      bottomNavigationBar: Padding(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-        child: FilledButton.icon(
-          onPressed: _canSave ? _save : null,
-          icon: const Icon(Icons.check),
-          label: const Text('Сохранить'),
-          style: FilledButton.styleFrom(
-            padding: const EdgeInsets.symmetric(vertical: 14),
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.red,
+            foregroundColor: Colors.white,
           ),
+          onPressed: _delete,
+          child: const Text('Удалить заметку'),
         ),
-      )
-          : null,
+      ),
 
     );
   }


### PR DESCRIPTION
## Summary
- move note deletion to bottom button and remove app bar delete icon
- show icons beside notes in contact details
- add helper text distinguishing required and optional fields in contact forms

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b000a8c1e08326b01753aaeb80c20a