### PR TITLE
Remove auto-scroll on restoring contacts and adjust detail deletion flow

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -820,7 +820,10 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
     final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
 
-    final ctx = App.navigatorKey.currentContext ?? context;
+    if (mounted) Navigator.pop(context, true);
+
+    final ctx = App.navigatorKey.currentContext;
+    if (ctx == null) return;
     final messenger = ScaffoldMessenger.of(ctx);
 
     const duration = Duration(seconds: 4);
@@ -838,7 +841,8 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
             _snackTimer?.cancel();
             messenger.hideCurrentSnackBar();
 
-            final newId = await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+            final newId =
+                await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
 
             await _goToRestored(c, newId);
           },
@@ -847,8 +851,6 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     );
 
     _snackTimer = Timer(endTime.difference(DateTime.now()), () => controller.close());
-
-    if (mounted) Navigator.pop(context, true);
   }
 
   String _titleForCategory(String cat) {
@@ -871,7 +873,6 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
         builder: (_) => ContactListScreen(
           category: restored.category,
           title: title,
-          scrollToId: restoredId,
         ),
       ),
     );

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -330,24 +330,23 @@ class _ContactListScreenState extends State<ContactListScreen> {
     }
   }
 
-  /// Переходит к нужной категории (если надо) и подсвечивает восстановленный контакт.
+  /// Обновляет список контактов и, если возможно, подсвечивает восстановленный контакт
+  /// без автопрокрутки.
   Future<void> _goToRestored(Contact restored, int restoredId) async {
     // уже на нужной категории
     if (mounted && widget.category == restored.category) {
       await _loadContacts(reset: true);
-      await _maybeScrollTo(restoredId);
       _flashHighlight(restoredId);
       return;
     }
 
-    // пушим новую страницу категории, она сама проскроллит и подсветит по scrollToId
+    // переходим в нужную категорию без прокрутки к восстановленному
     final String title = _titleForCategory(restored.category);
     App.navigatorKey.currentState?.push(
       MaterialPageRoute(
         builder: (_) => ContactListScreen(
           category: restored.category,
           title: title,
-          scrollToId: restoredId,
         ),
       ),
     );
@@ -597,9 +596,6 @@ class _ContactListScreenState extends State<ContactListScreen> {
                           ),
                         );
                         await _loadContacts(reset: true);
-                        if (deleted == true && mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Контакт удалён')));
-                        }
                       },
                       pulse: isHighlighted,
                       pulseSeed:


### PR DESCRIPTION
## Summary
- Remove auto-scroll and scrollId usage when restoring contacts
- Close detail view before showing undo snackbar after contact deletion
- Drop redundant deletion toast when returning from details

## Testing
- `flutter format lib/screens/contact_list_screen.dart lib/screens/contact_details_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84772ce788326b37fbe18c7cd9894