### PR TITLE
Remove auto-scroll on restoring contacts and adjust detail deletion flow

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -820,7 +820,10 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
     final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
 
-    final ctx = App.navigatorKey.currentContext ?? context;
+    if (mounted) Navigator.pop(context, true);
+
+    final ctx = App.navigatorKey.currentContext;
+    if (ctx == null) return;
     final messenger = ScaffoldMessenger.of(ctx);
 
     const duration = Duration(seconds: 4);
@@ -838,43 +841,16 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
             _snackTimer?.cancel();
             messenger.hideCurrentSnackBar();
 
-            final newId = await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+            final newId =
+                await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
 
-            await _goToRestored(c, newId);
+            await ContactListScreen.goToRestored(c, newId);
           },
         ),
       ),
     );
 
     _snackTimer = Timer(endTime.difference(DateTime.now()), () => controller.close());
-
-    if (mounted) Navigator.pop(context, true);
-  }
-
-  String _titleForCategory(String cat) {
-    switch (cat) {
-      case 'Партнёр':
-        return 'Партнёры';
-      case 'Клиент':
-        return 'Клиенты';
-      case 'Потенциальный':
-        return 'Потенциальные';
-      default:
-        return cat;
-    }
-  }
-
-  Future<void> _goToRestored(Contact restored, int restoredId) async {
-    final title = _titleForCategory(restored.category);
-    App.navigatorKey.currentState?.push(
-      MaterialPageRoute(
-        builder: (_) => ContactListScreen(
-          category: restored.category,
-          title: title,
-          scrollToId: restoredId,
-        ),
-      ),
-    );
   }
 
   Future<void> _delete() async {


### PR DESCRIPTION
## Summary
- Centralize contact restoration logic in `ContactListScreen.goToRestored` to reuse existing list and highlight restored entries
- Use the new helper from contact details undo flow, preventing duplicate list screens

## Testing
- `flutter format lib/screens/contact_list_screen.dart lib/screens/contact_details_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b84772ce788326b37fbe18c7cd9894