### PR TITLE
feat: improve contact database for production

### DIFF
--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -109,6 +109,16 @@ class ContactDatabase {
     return _db!;
   }
 
+  /// Закрывает подключение к базе. При следующем обращении [database]
+  /// соединение будет открыто заново. Полезно вызывать при завершении
+  /// приложения, чтобы избежать утечек ресурсов в продакшене.
+  Future<void> close() async {
+    if (_db != null) {
+      await _db!.close();
+      _db = null;
+    }
+  }
+
   // ---- Вспомогательное: карта для insert без id ----
   Map<String, Object?> _mapForInsert(Map<String, Object?> src) {
     final m = Map<String, Object?>.from(src);
@@ -253,13 +263,24 @@ class ContactDatabase {
 
   /// Удаляет контакт (каскадно удаляются заметки) и возвращает снапшот заметок.
   /// В UI можно сохранить возвращённый список для последующего Undo.
+  ///
+  /// Операция обёрнута в транзакцию, чтобы снимок и удаление были атомарными.
   Future<List<Note>> deleteContactWithSnapshot(int contactId) async {
     final db = await database;
-    // Снимок заметок до удаления
-    final snapshot = await notesByContact(contactId);
+    final snapshot = <Note>[];
 
-    // Удаляем контакт — FK прибьёт notes
-    await db.delete('contacts', where: 'id = ?', whereArgs: [contactId]);
+    await db.transaction((txn) async {
+      final maps = await txn.query(
+        'notes',
+        where: 'contactId = ?',
+        whereArgs: [contactId],
+        orderBy: 'createdAt DESC',
+      );
+      snapshot.addAll(maps.map(Note.fromMap));
+
+      // Удаляем контакт — FK каскадно удалит связанные заметки
+      await txn.delete('contacts', where: 'id = ?', whereArgs: [contactId]);
+    });
 
     _bumpRevision();
     return snapshot;


### PR DESCRIPTION
## Summary
- add `close` method for ContactDatabase to release resources
- wrap contact deletion and snapshot in transaction for atomicity

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0845dff08326ae6e0b2a1686d197