### PR TITLE
Add location-based localization and theme picker

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <application
         android:label="touchnotebookbeta_flutter"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,9 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+  <key>UIApplicationSupportsIndirectInputEvents</key>
+  <true/>
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>Need location to determine your country</string>
 </dict>
 </plist>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'screens/home_screen.dart';
+import 'services/settings_controller.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
@@ -12,36 +13,41 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Touch NoteBook',
-      debugShowCheckedModeBanner: false, // 🔔 убирает "DEBUG" в углу
-      navigatorKey: navigatorKey, // <-- ВАЖНО: подключили ключ
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.deepPurple,
-          brightness: Brightness.light,
-        ),
-        useMaterial3: true,
-      ),
-      darkTheme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.deepPurple,
-          brightness: Brightness.dark,
-        ),
-        useMaterial3: true,
-      ),
-      themeMode: ThemeMode.system,
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [
-        Locale('ru'),
-        Locale('en'),
-      ],
-      locale: const Locale('ru'),
-      home: const HomeScreen(),
+    return AnimatedBuilder(
+      animation: settingsController,
+      builder: (context, _) {
+        return MaterialApp(
+          title: 'Touch NoteBook',
+          debugShowCheckedModeBanner: false, // 🔔 убирает "DEBUG" в углу
+          navigatorKey: navigatorKey, // <-- ВАЖНО: подключили ключ
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: Colors.deepPurple,
+              brightness: Brightness.light,
+            ),
+            useMaterial3: true,
+          ),
+          darkTheme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: Colors.deepPurple,
+              brightness: Brightness.dark,
+            ),
+            useMaterial3: true,
+          ),
+          themeMode: settingsController.themeMode,
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: const [
+            Locale('ru'),
+            Locale('en'),
+          ],
+          locale: settingsController.locale,
+          home: const HomeScreen(),
+        );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,20 @@
 import 'package:flutter/material.dart';
 
 import 'app.dart';
+import 'services/settings_controller.dart';
+import 'screens/settings_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await settingsController.initialize();
   runApp(const App());
+
+  if (!settingsController.isLocaleSet) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      App.navigatorKey.currentState?.push(
+        MaterialPageRoute(builder: (_) => const SettingsScreen()),
+      );
+    });
+  }
 }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,15 +1,70 @@
 import 'package:flutter/material.dart';
+import '../services/settings_controller.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Настройки')),
-      body: const Center(
-        child: Text('Страница в разработке'),
-      ),
+    return AnimatedBuilder(
+      animation: settingsController,
+      builder: (context, _) {
+        return Scaffold(
+          appBar: AppBar(title: const Text('Настройки')),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Тема'),
+                DropdownButton<ThemeMode>(
+                  value: settingsController.themeMode,
+                  items: const [
+                    DropdownMenuItem(
+                      value: ThemeMode.system,
+                      child: Text('Как в системе'),
+                    ),
+                    DropdownMenuItem(
+                      value: ThemeMode.light,
+                      child: Text('Светлая'),
+                    ),
+                    DropdownMenuItem(
+                      value: ThemeMode.dark,
+                      child: Text('Тёмная'),
+                    ),
+                  ],
+                  onChanged: (mode) {
+                    if (mode != null) {
+                      settingsController.updateThemeMode(mode);
+                    }
+                  },
+                ),
+                const SizedBox(height: 24),
+                const Text('Страна'),
+                DropdownButton<Locale>(
+                  value: settingsController.locale,
+                  hint: const Text('Выберите страну'),
+                  items: const [
+                    DropdownMenuItem(
+                      value: Locale('ru'),
+                      child: Text('Россия'),
+                    ),
+                    DropdownMenuItem(
+                      value: Locale('en'),
+                      child: Text('США'),
+                    ),
+                  ],
+                  onChanged: (loc) {
+                    if (loc != null) {
+                      settingsController.updateLocale(loc);
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/services/localization_service.dart
+++ b/lib/services/localization_service.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+import 'package:geocoding/geocoding.dart';
+import 'package:geolocator/geolocator.dart';
+
+class LocalizationService {
+  static Future<Locale> getLocaleFromLocation() async {
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      throw Exception('Location disabled');
+    }
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        throw Exception('Permission denied');
+      }
+    }
+    if (permission == LocationPermission.deniedForever) {
+      throw Exception('Permission denied forever');
+    }
+    final position = await Geolocator.getCurrentPosition();
+    final placemarks = await placemarkFromCoordinates(position.latitude, position.longitude);
+    final code = placemarks.first.isoCountryCode?.toLowerCase() ?? 'en';
+    switch (code) {
+      case 'ru':
+        return const Locale('ru');
+      default:
+        return const Locale('en');
+    }
+  }
+}

--- a/lib/services/settings_controller.dart
+++ b/lib/services/settings_controller.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'localization_service.dart';
+
+class SettingsController extends ChangeNotifier {
+  ThemeMode themeMode = ThemeMode.system;
+  Locale? locale;
+
+  Future<void> initialize() async {
+    try {
+      locale = await LocalizationService.getLocaleFromLocation();
+    } catch (_) {
+      locale = null; // user will select manually
+    }
+  }
+
+  bool get isLocaleSet => locale != null;
+
+  void updateThemeMode(ThemeMode mode) {
+    themeMode = mode;
+    notifyListeners();
+  }
+
+  void updateLocale(Locale newLocale) {
+    locale = newLocale;
+    notifyListeners();
+  }
+}
+
+final settingsController = SettingsController();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
   path_provider: ^2.1.2
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
+  geolocator: ^11.0.0
+  geocoding: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- detect locale from device location and request manual country if unavailable
- allow switching theme (system/light/dark) and country in settings
- add required Android and iOS location permissions

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb131426c88326ac94123a2c844619