### PR TITLE
Remove FAB icons and unify add labels

### DIFF
--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -697,8 +697,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
             }
           }
         },
-        icon: const Icon(Icons.add),
-        label: const Text('Добавить'),
+        label: const Text('Добавить контакт'),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -169,7 +169,6 @@ class _HomeScreenState extends State<HomeScreen> {
             );
           }
         },
-        icon: const Icon(Icons.add),
         label: const Text('Добавить контакт'),
       ),
     );

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -351,9 +351,9 @@ class _NotesListScreenState extends State<NotesListScreen> {
         ],
       ),
       body: content,
-      floatingActionButton: FloatingActionButton(
+      floatingActionButton: FloatingActionButton.extended(
         onPressed: _addNote,
-        child: const Icon(Icons.add),
+        label: const Text('Добавить заметку'),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Remove plus icons from contact and note FABs
- Keep "Добавить контакт" label on home and contact list FABs
- Use text-only "Добавить заметку" button for notes

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb30611004832685a66ebc352e60fe