### PR TITLE
fix: stabilize AppBar color and tweak spacing

### DIFF
--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -833,7 +833,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
         child: ExpansionTile(
           initiallyExpanded: expanded,
           tilePadding: const EdgeInsets.symmetric(horizontal: 16),
-          childrenPadding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+          childrenPadding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
           onExpansionChanged: onChanged,
           maintainState: true,
           trailing: const SizedBox.shrink(),

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -997,7 +997,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
         child: ExpansionTile(
           initiallyExpanded: expanded,
           tilePadding: const EdgeInsets.only(left: 16, right: 0),
-          childrenPadding: const EdgeInsets.fromLTRB(24, 0, 16, 16),
+          childrenPadding: const EdgeInsets.fromLTRB(24, 16, 16, 16),
           onExpansionChanged: onChanged,
           maintainState: true,
           trailing: const SizedBox.shrink(),
@@ -1386,19 +1386,24 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     Card(
                       elevation: 0,
                       child: Column(
-                        children: ListTile.divideTiles(
-                          context: context,
-                          tiles: _notes.map((n) => ListTile(
-                            leading:
-                            const Icon(Icons.sticky_note_2_outlined),
-                            title: Text(n.text,
+                        children: [
+                          for (var i = 0; i < _notes.length; i++) ...[
+                            ListTile(
+                              leading: const Icon(Icons.sticky_note_2_outlined),
+                              title: Text(
+                                _notes[i].text,
                                 maxLines: 2,
-                                overflow: TextOverflow.ellipsis),
-                            subtitle: Text(DateFormat('dd.MM.yyyy')
-                                .format(n.createdAt)),
-                            onTap: () => _openNote(n),
-                          )),
-                        ).toList(),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              subtitle: Text(
+                                DateFormat('dd.MM.yyyy').format(_notes[i].createdAt),
+                              ),
+                              onTap: () => _openNote(_notes[i]),
+                            ),
+                            if (i < _notes.length - 1)
+                              const Divider(indent: 72, height: 0, thickness: 1),
+                          ],
+                        ],
                       ),
                     ),
                   ],

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -536,6 +536,8 @@ class _ContactListScreenState extends State<ContactListScreen> {
       appBar: AppBar(
         leading: const BackButton(),
         title: Text(widget.title),
+        surfaceTintColor: Colors.transparent,
+        scrolledUnderElevation: 0,
         actions: [
           IconButton(icon: const Icon(Icons.sort), onPressed: _openSort),
           IconButton(icon: const Icon(Icons.filter_alt), onPressed: _openFilters),


### PR DESCRIPTION
## Summary
- keep contact list AppBar color consistent when scrolled
- add top padding in Additional sections so birth field hint is fully visible
- align note dividers with text start

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb32a9118c83268869e0e57472ef00