### PR TITLE
Handle FutureBuilder errors on HomeScreen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -162,6 +162,17 @@ class _HomeScreenState extends State<HomeScreen> {
               child: FutureBuilder<List<int>>(
                 future: future,
                 builder: (context, snapshot) {
+                  if (snapshot.hasError) {
+                    debugPrint('Error loading contact counts: ${snapshot.error}\n${snapshot.stackTrace}');
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      if (!mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Не удалось загрузить данные')),
+                      );
+                    });
+                    return const Center(child: Text('Ошибка загрузки данных'));
+                  }
+
                   final isLoading = snapshot.connectionState == ConnectionState.waiting;
                   final counts = snapshot.data ?? const [0, 0, 0];
 


### PR DESCRIPTION
## Summary
- handle FutureBuilder errors by checking `snapshot.hasError`
- log error details and show snackbar with error message

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c13a9c89cc8326a8e50eee542a8981