### PR TITLE
Use Intl.plural for contact category counts

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
 
 class AppLocalizations {
   AppLocalizations(this.locale);
@@ -25,19 +26,31 @@ class AppLocalizations {
   String get addContact => 'Добавить контакт';
   String get partnersTitle => 'Партнёры';
   String get partnersValue => 'Партнёр';
-  String get partnersFormOne => 'партнёр';
-  String get partnersFormFew => 'партнёра';
-  String get partnersFormMany => 'партнёров';
+  String partnersCount(int count) => Intl.plural(
+        count,
+        one: '$count партнёр',
+        few: '$count партнёра',
+        many: '$count партнёров',
+        other: '$count партнёра',
+      );
   String get clientsTitle => 'Клиенты';
   String get clientsValue => 'Клиент';
-  String get clientsFormOne => 'клиент';
-  String get clientsFormFew => 'клиента';
-  String get clientsFormMany => 'клиентов';
+  String clientsCount(int count) => Intl.plural(
+        count,
+        one: '$count клиент',
+        few: '$count клиента',
+        many: '$count клиентов',
+        other: '$count клиента',
+      );
   String get potentialTitle => 'Потенциальные';
   String get potentialValue => 'Потенциальный';
-  String get potentialFormOne => 'потенциальный';
-  String get potentialFormFew => 'потенциальных';
-  String get potentialFormMany => 'потенциальных';
+  String potentialCount(int count) => Intl.plural(
+        count,
+        one: '$count потенциальный',
+        few: '$count потенциальных',
+        many: '$count потенциальных',
+        other: '$count потенциальных',
+      );
   String get ellipsis => '…';
 }
 

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -19,18 +19,33 @@
   "addContact": "Добавить контакт",
   "partnersTitle": "Партнёры",
   "partnersValue": "Партнёр",
-  "partnersFormOne": "партнёр",
-  "partnersFormFew": "партнёра",
-  "partnersFormMany": "партнёров",
+  "partnersCount": "{count, plural, one{{count} партнёр} few{{count} партнёра} many{{count} партнёров} other{{count} партнёра}}",
+  "@partnersCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "clientsTitle": "Клиенты",
   "clientsValue": "Клиент",
-  "clientsFormOne": "клиент",
-  "clientsFormFew": "клиента",
-  "clientsFormMany": "клиентов",
+  "clientsCount": "{count, plural, one{{count} клиент} few{{count} клиента} many{{count} клиентов} other{{count} клиента}}",
+  "@clientsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "potentialTitle": "Потенциальные",
   "potentialValue": "Потенциальный",
-  "potentialFormOne": "потенциальный",
-  "potentialFormFew": "потенциальных",
-  "potentialFormMany": "потенциальных",
+  "potentialCount": "{count, plural, one{{count} потенциальный} few{{count} потенциальных} many{{count} потенциальных} other{{count} потенциальных}}",
+  "@potentialCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "ellipsis": "…"
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -79,16 +79,6 @@ class _HomeScreenState extends State<HomeScreen> {
     }
   }
 
-  String _plural(int count, List<String> forms) {
-    final mod10 = count % 10;
-    final mod100 = count % 100;
-    if (mod10 == 1 && mod100 != 11) return forms[0];
-    if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) {
-      return forms[1];
-    }
-    return forms[2];
-  }
-
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -184,9 +174,8 @@ class _HomeScreenState extends State<HomeScreen> {
                       itemBuilder: (context, index) {
                         final cat = categories[index];
                         final count = isLoading ? null : counts[index];
-                        final subtitle = count == null
-                            ? l10n.ellipsis
-                            : '$count ${_plural(count, cat.forms)}';
+                        final subtitle =
+                            count == null ? l10n.ellipsis : cat.plural(count);
 
                         return _CategoryCard(
                           category: cat,
@@ -235,13 +224,13 @@ class _Category {
   final IconData icon;
   final String title;
   final String value;
-  final List<String> forms;
+  final String Function(int) plural;
 
   const _Category({
     required this.icon,
     required this.title,
     required this.value,
-    required this.forms,
+    required this.plural,
   });
 }
 
@@ -250,19 +239,19 @@ List<_Category> _categories(AppLocalizations l10n) => [
         icon: Icons.handshake,
         title: l10n.partnersTitle,
         value: l10n.partnersValue,
-        forms: [l10n.partnersFormOne, l10n.partnersFormFew, l10n.partnersFormMany],
+        plural: l10n.partnersCount,
       ),
       _Category(
         icon: Icons.people,
         title: l10n.clientsTitle,
         value: l10n.clientsValue,
-        forms: [l10n.clientsFormOne, l10n.clientsFormFew, l10n.clientsFormMany],
+        plural: l10n.clientsCount,
       ),
       _Category(
         icon: Icons.person_add_alt_1,
         title: l10n.potentialTitle,
         value: l10n.potentialValue,
-        forms: [l10n.potentialFormOne, l10n.potentialFormFew, l10n.potentialFormMany],
+        plural: l10n.potentialCount,
       ),
     ];
 


### PR DESCRIPTION
## Summary
- remove custom plural logic in HomeScreen
- add ICU plural messages and corresponding localization methods
- display category counts using generated Intl.plural strings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16e8edc6c832680107346a6d9e70a