### PR TITLE
Add locale selection with persistence

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,8 +1,10 @@
 // lib/app.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:provider/provider.dart';
 import 'l10n/app_localizations.dart';
 import 'screens/home_screen.dart';
+import 'services/locale_notifier.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
@@ -13,6 +15,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final locale = context.watch<LocaleNotifier>().locale;
     return MaterialApp(
       onGenerateTitle: (context) => AppLocalizations.of(context)!.appTitle,
       debugShowCheckedModeBanner: false, // 🔔 убирает "DEBUG" в углу
@@ -43,7 +46,7 @@ class App extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
       supportedLocales: AppLocalizations.supportedLocales,
-      locale: const Locale('ru'),
+      locale: locale,
       home: const HomeScreen(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/material.dart';
 
 import 'app.dart';
+import 'services/locale_notifier.dart';
+import 'package:provider/provider.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(const App());
+  final localeNotifier = LocaleNotifier();
+  await localeNotifier.loadLocale();
+  runApp(
+    ChangeNotifierProvider<LocaleNotifier>.value(
+      value: localeNotifier,
+      child: const App(),
+    ),
+  );
 }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,14 +1,39 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../services/locale_notifier.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final locale = context.watch<LocaleNotifier>().locale;
     return Scaffold(
       appBar: AppBar(title: const Text('Настройки')),
-      body: const Center(
-        child: Text('Страница в разработке'),
+      body: ListView(
+        children: [
+          const ListTile(title: Text('Язык')),
+          RadioListTile<Locale>(
+            title: const Text('Русский'),
+            value: const Locale('ru'),
+            groupValue: locale,
+            onChanged: (value) {
+              if (value != null) {
+                context.read<LocaleNotifier>().setLocale(value);
+              }
+            },
+          ),
+          RadioListTile<Locale>(
+            title: const Text('English'),
+            value: const Locale('en'),
+            groupValue: locale,
+            onChanged: (value) {
+              if (value != null) {
+                context.read<LocaleNotifier>().setLocale(value);
+              }
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/services/locale_notifier.dart
+++ b/lib/services/locale_notifier.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// [ChangeNotifier] that stores the selected [Locale] in [SharedPreferences].
+class LocaleNotifier extends ChangeNotifier {
+  static const _storageKey = 'localeCode';
+
+  Locale _locale = const Locale('ru');
+
+  /// Current locale of the application.
+  Locale get locale => _locale;
+
+  /// Loads the saved locale from [SharedPreferences].
+  Future<void> loadLocale() async {
+    final prefs = await SharedPreferences.getInstance();
+    final code = prefs.getString(_storageKey);
+    if (code != null) {
+      _locale = Locale(code);
+      notifyListeners();
+    }
+  }
+
+  /// Updates the locale and persists it in [SharedPreferences].
+  Future<void> setLocale(Locale locale) async {
+    _locale = locale;
+    notifyListeners();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, locale.languageCode);
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,8 @@ dependencies:
   path_provider: ^2.1.2
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
+  shared_preferences: ^2.2.2
+  provider: ^6.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add LocaleNotifier storing selected language in SharedPreferences
- use LocaleNotifier in MaterialApp to switch locale
- add language selector to settings screen

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c19d1c845483268797e3605e2417ba