### PR TITLE
Fix category localization for stable data access

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -18,7 +18,6 @@
   "contactSaved": "Contact saved",
   "addContact": "Add contact",
   "partnersTitle": "Partners",
-  "partnersValue": "Partner",
   "partnersCount": "{count, plural, one{{count} partner} other{{count} partners}}",
   "@partnersCount": {
     "placeholders": {
@@ -28,7 +27,6 @@
     }
   },
   "clientsTitle": "Clients",
-  "clientsValue": "Client",
   "clientsCount": "{count, plural, one{{count} client} other{{count} clients}}",
   "@clientsCount": {
     "placeholders": {
@@ -38,8 +36,8 @@
     }
   },
   "potentialTitle": "Potential",
-  "potentialValue": "Potential",
   "potentialCount": "{count, plural, one{{count} potential} other{{count} potential}}",
+  "category": "Category",
   "@potentialCount": {
     "placeholders": {
       "count": {

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -18,7 +18,6 @@
   "contactSaved": "Контакт сохранён",
   "addContact": "Добавить контакт",
   "partnersTitle": "Партнёры",
-  "partnersValue": "Партнёр",
   "partnersCount": "{count, plural, one{{count} партнёр} few{{count} партнёра} many{{count} партнёров} other{{count} партнёра}}",
   "@partnersCount": {
     "placeholders": {
@@ -28,7 +27,6 @@
     }
   },
   "clientsTitle": "Клиенты",
-  "clientsValue": "Клиент",
   "clientsCount": "{count, plural, one{{count} клиент} few{{count} клиента} many{{count} клиентов} other{{count} клиента}}",
   "@clientsCount": {
     "placeholders": {
@@ -38,8 +36,8 @@
     }
   },
   "potentialTitle": "Потенциальные",
-  "potentialValue": "Потенциальный",
   "potentialCount": "{count, plural, one{{count} потенциальный} few{{count} потенциальных} many{{count} потенциальных} other{{count} потенциальных}}",
+  "category": "Категория",
   "@potentialCount": {
     "placeholders": {
       "count": {

--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -6,6 +6,7 @@ import 'package:characters/characters.dart';
 
 import '../models/contact.dart';
 import '../services/contact_database.dart';
+import '../l10n/app_localizations.dart';
 
 class AddContactScreen extends StatefulWidget {
   final String? category; // preselected category (singular)
@@ -622,16 +623,19 @@ class _AddContactScreenState extends State<AddContactScreen> {
     final result = await showModalBottomSheet<String>(
       context: context,
       showDragHandle: true,
-      builder: (context) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: const [
-            _PickerTile(icon: Icons.handshake, label: 'Партнёр', value: 'Партнёр'),
-            _PickerTile(icon: Icons.people, label: 'Клиент', value: 'Клиент'),
-            _PickerTile(icon: Icons.person_add_alt_1, label: 'Потенциальный', value: 'Потенциальный'),
-          ],
-        ),
-      ),
+      builder: (context) {
+        final l10n = AppLocalizations.of(context)!;
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _PickerTile(icon: Icons.handshake, label: l10n.partnersTitle, value: 'Партнёр'),
+              _PickerTile(icon: Icons.people, label: l10n.clientsTitle, value: 'Клиент'),
+              _PickerTile(icon: Icons.person_add_alt_1, label: l10n.potentialTitle, value: 'Потенциальный'),
+            ],
+          ),
+        );
+      },
     );
 
     setState(() => _categoryOpen = false);

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -13,6 +13,7 @@ import 'contact_list_screen.dart'; // переход к восстановлен
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
 import 'note_details_screen.dart';
+import '../l10n/app_localizations.dart';
 
 class ContactDetailsScreen extends StatefulWidget {
   final Contact contact;
@@ -930,36 +931,39 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
         borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
       ),
       clipBehavior: Clip.antiAlias,
-      builder: (context) => _sheetWrap(
-        title: 'Категория',
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _radioRow<String>(
-              value: 'Партнёр',
-              groupValue: _category,
-              title: 'Партнёр',
-              icon: Icons.handshake,
-              onSelect: () => Navigator.pop(context, 'Партнёр'),
-            ),
-            _radioRow<String>(
-              value: 'Клиент',
-              groupValue: _category,
-              title: 'Клиент',
-              icon: Icons.people,
-              onSelect: () => Navigator.pop(context, 'Клиент'),
-            ),
-            _radioRow<String>(
-              value: 'Потенциальный',
-              groupValue: _category,
-              title: 'Потенциальный',
-              icon: Icons.person_add_alt_1,
-              onSelect: () => Navigator.pop(context, 'Потенциальный'),
-              isLast: true,
-            ),
-          ],
-        ),
-      ),
+      builder: (context) {
+        final l10n = AppLocalizations.of(context)!;
+        return _sheetWrap(
+          title: l10n.category,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _radioRow<String>(
+                value: 'Партнёр',
+                groupValue: _category,
+                title: l10n.partnersTitle,
+                icon: Icons.handshake,
+                onSelect: () => Navigator.pop(context, 'Партнёр'),
+              ),
+              _radioRow<String>(
+                value: 'Клиент',
+                groupValue: _category,
+                title: l10n.clientsTitle,
+                icon: Icons.people,
+                onSelect: () => Navigator.pop(context, 'Клиент'),
+              ),
+              _radioRow<String>(
+                value: 'Потенциальный',
+                groupValue: _category,
+                title: l10n.potentialTitle,
+                icon: Icons.person_add_alt_1,
+                onSelect: () => Navigator.pop(context, 'Потенциальный'),
+                isLast: true,
+              ),
+            ],
+          ),
+        );
+      },
     );
 
 
@@ -1145,21 +1149,22 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     _snackTimer = Timer(endTime.difference(DateTime.now()), () => controller.close());
   }
 
-  String _titleForCategory(String cat) {
+  String _titleForCategory(BuildContext context, String cat) {
+    final l10n = AppLocalizations.of(context)!;
     switch (cat) {
       case 'Партнёр':
-        return 'Партнёры';
+        return l10n.partnersTitle;
       case 'Клиент':
-        return 'Клиенты';
+        return l10n.clientsTitle;
       case 'Потенциальный':
-        return 'Потенциальные';
+        return l10n.potentialTitle;
       default:
         return cat;
     }
   }
 
   Future<void> _goToRestored(Contact restored, int restoredId) async {
-    final title = _titleForCategory(restored.category);
+    final title = _titleForCategory(context, restored.category);
     App.navigatorKey.currentState?.push(
       MaterialPageRoute(
         builder: (_) => ContactListScreen(

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -7,6 +7,7 @@ import '../services/contact_database.dart';
 import 'add_contact_screen.dart';
 import 'contact_details_screen.dart';
 import 'package:characters/characters.dart';
+import '../l10n/app_localizations.dart';
 
 class ContactListScreen extends StatefulWidget {
   final String category; // singular value for DB
@@ -21,13 +22,16 @@ class ContactListScreen extends StatefulWidget {
   });
 
   static String _titleForCategory(String cat) {
+    final ctx = App.navigatorKey.currentContext;
+    if (ctx == null) return cat;
+    final l10n = AppLocalizations.of(ctx)!;
     switch (cat) {
       case 'Партнёр':
-        return 'Партнёры';
+        return l10n.partnersTitle;
       case 'Клиент':
-        return 'Клиенты';
+        return l10n.clientsTitle;
       case 'Потенциальный':
-        return 'Потенциальные';
+        return l10n.potentialTitle;
       default:
         return cat;
     }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -214,19 +214,19 @@ List<_Category> _categories(AppLocalizations l10n) => [
       _Category(
         icon: Icons.handshake,
         title: l10n.partnersTitle,
-        value: l10n.partnersValue,
+        value: 'Партнёр',
         plural: l10n.partnersCount,
       ),
       _Category(
         icon: Icons.people,
         title: l10n.clientsTitle,
-        value: l10n.clientsValue,
+        value: 'Клиент',
         plural: l10n.clientsCount,
       ),
       _Category(
         icon: Icons.person_add_alt_1,
         title: l10n.potentialTitle,
-        value: l10n.potentialValue,
+        value: 'Потенциальный',
         plural: l10n.potentialCount,
       ),
     ];

--- a/test/screens/home_screen_test.dart
+++ b/test/screens/home_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:touchnotebookbeta_flutter/screens/add_contact_screen.dart';
 import 'package:touchnotebookbeta_flutter/screens/contact_list_screen.dart';
 import 'package:touchnotebookbeta_flutter/services/contact_database.dart';
 import 'package:touchnotebookbeta_flutter/models/contact.dart';
+import 'package:touchnotebookbeta_flutter/l10n/app_localizations.dart';
 
 class MockContactDatabase extends Mock implements ContactDatabase {}
 
@@ -45,7 +46,12 @@ void main() {
   });
 
   testWidgets('category cards display correct counts and plural forms', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ru'),
+      home: const HomeScreen(),
+    ));
     await tester.pump(); // start future
     await tester.pump(); // finish future
 
@@ -55,7 +61,12 @@ void main() {
   });
 
   testWidgets('tapping category navigates to ContactListScreen', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ru'),
+      home: const HomeScreen(),
+    ));
     await tester.pump();
     await tester.pump();
 
@@ -66,7 +77,12 @@ void main() {
   });
 
   testWidgets('tapping FAB navigates to AddContactScreen and refreshes counts on return', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ru'),
+      home: const HomeScreen(),
+    ));
     await tester.pump();
     await tester.pump();
 
@@ -90,7 +106,12 @@ void main() {
 
 
   testWidgets('manual refresh reloads counts without revision change', (tester) async {
-    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ru'),
+      home: const HomeScreen(),
+    ));
     await tester.pump();
     await tester.pump();
 


### PR DESCRIPTION
## Summary
- Use locale-independent category values and localize only titles
- Localize category pickers and navigation titles
- Add "Category" translation and update tests for localization

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dart format lib test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a06ca1c08326b75391568d3940b8