### PR TITLE
Localize note details screen

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -45,5 +45,22 @@
       }
     }
   },
-  "ellipsis": "…"
+  "ellipsis": "…",
+  "noteSaved": "Note saved",
+  "deleteNoteQuestion": "Delete note?",
+  "deleteNoteWarning": "This action cannot be undone.",
+  "cancel": "Cancel",
+  "delete": "Delete",
+  "undo": "Undo",
+  "close": "Close",
+  "note": "Note",
+  "save": "Save",
+  "text": "Text",
+  "noteTextLabel": "Note text*",
+  "enterText": "Enter text",
+  "date": "Date",
+  "dateAdded": "Date added",
+  "deleteNote": "Delete note",
+  "noteDeleted": "Note deleted",
+  "secondsShort": "s"
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -45,5 +45,22 @@
       }
     }
   },
-  "ellipsis": "…"
+  "ellipsis": "…",
+  "noteSaved": "Заметка сохранена",
+  "deleteNoteQuestion": "Удалить заметку?",
+  "deleteNoteWarning": "Это действие нельзя отменить.",
+  "cancel": "Отмена",
+  "delete": "Удалить",
+  "undo": "Отменить",
+  "close": "Закрыть",
+  "note": "Заметка",
+  "save": "Сохранить",
+  "text": "Текст",
+  "noteTextLabel": "Текст заметки*",
+  "enterText": "Введите текст",
+  "date": "Дата",
+  "dateAdded": "Дата добавления",
+  "deleteNote": "Удалить заметку",
+  "noteDeleted": "Заметка удалена",
+  "secondsShort": "с"
 }

--- a/lib/screens/note_details_screen.dart
+++ b/lib/screens/note_details_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../app.dart'; // для App.navigatorKey
 import '../models/note.dart';
 import '../services/contact_database.dart';
+import '../l10n/app_localizations.dart';
 
 class NoteDetailsScreen extends StatefulWidget {
   final Note note;
@@ -125,7 +126,7 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
       initialDate: _date,
       firstDate: DateTime(2000),
       lastDate: now,
-      locale: const Locale('ru'),
+      locale: Localizations.localeOf(context),
     );
     if (picked != null) {
       setState(() {
@@ -151,8 +152,9 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
     // ✅ показываем SnackBar так, чтобы он остался после pop
     final rootCtx = App.navigatorKey.currentContext;
     if (rootCtx != null) {
+      final l10nRoot = AppLocalizations.of(rootCtx)!;
       ScaffoldMessenger.of(rootCtx).showSnackBar(
-        const SnackBar(content: Text('Заметка сохранена')),
+        SnackBar(content: Text(l10nRoot.noteSaved)),
       );
     }
 
@@ -162,14 +164,18 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
 
 
   Future<void> _delete() async {
+    final l10n = AppLocalizations.of(context)!;
     final ok = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('Удалить заметку?'),
-        content: const Text('Это действие нельзя отменить.'),
+        title: Text(l10n.deleteNoteQuestion),
+        content: Text(l10n.deleteNoteWarning),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Отмена')),
-          TextButton(onPressed: () => Navigator.pop(context, true), child: const Text('Удалить', style: TextStyle(color: Colors.red))),
+          TextButton(onPressed: () => Navigator.pop(context, false), child: Text(l10n.cancel)),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(l10n.delete, style: const TextStyle(color: Colors.red)),
+          ),
         ],
       ),
     );
@@ -190,7 +196,7 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
         duration: const Duration(days: 1),
         content: _UndoSnackContentLocal(endTime: endTime, duration: duration),
         action: SnackBarAction(
-          label: 'Отменить',
+          label: l10n.undo,
           onPressed: () async {
             _snackTimer?.cancel();
             messenger.hideCurrentSnackBar();
@@ -222,20 +228,21 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final dateStr = DateFormat('dd.MM.yyyy').format(_date);
 
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
-          tooltip: 'Закрыть',
+          tooltip: l10n.close,
           icon: const Icon(Icons.close),
           onPressed: () => Navigator.pop(context),
         ),
-        title: const Text('Заметка'),
+        title: Text(l10n.note),
         actions: [
           if (_isEditing)
             IconButton(
-              tooltip: 'Сохранить',
+              tooltip: l10n.save,
               icon: const Icon(Icons.check),
               onPressed: _canSave ? _save : null,
             ),
@@ -254,7 +261,7 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
                 physics: const BouncingScrollPhysics(),
                 children: [
                   _sectionCard(
-                    title: 'Текст',
+                    title: l10n.text,
                     children: [
                       TextFormField(
                         controller: _textController,
@@ -262,23 +269,23 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
                         maxLines: null,
                         textInputAction: TextInputAction.newline,
                         decoration: _outlinedDec(
-                          label: 'Текст заметки*',
-                          hint: 'Введите текст',
+                          label: l10n.noteTextLabel,
+                          hint: l10n.enterText,
                           prefixIcon: Icons.notes_outlined,
                         ),
-                        validator: (v) => (v == null || v.trim().isEmpty) ? 'Введите текст' : null,
+                        validator: (v) => (v == null || v.trim().isEmpty) ? l10n.enterText : null,
                         onChanged: (_) => setState(() => _isEditing = _isDirty),
                       ),
                     ],
                   ),
                   _sectionCard(
-                    title: 'Дата',
+                    title: l10n.date,
                     children: [
                       _borderedTile(
                         child: ListTile(
                           contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
                           leading: const Icon(Icons.event_outlined),
-                          title: const Text('Дата добавления'),
+                          title: Text(l10n.dateAdded),
                           subtitle: Text(dateStr),
                           trailing: const Icon(Icons.arrow_drop_down),
                           onTap: _pickDate,
@@ -301,7 +308,7 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
             foregroundColor: Colors.white,
           ),
           onPressed: _delete,
-          child: const Text('Удалить заметку'),
+          child: Text(l10n.deleteNote),
         ),
       ),
 
@@ -374,11 +381,12 @@ class _UndoSnackContentLocalState extends State<_UndoSnackContentLocal>
   Widget build(BuildContext context) {
     final value = _ctrl.value;
     final secondsLeft = (value * widget.duration.inSeconds).ceil().clamp(0, 999);
+    final l10n = AppLocalizations.of(context)!;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(children: [const Expanded(child: Text('Заметка удалена')), Text('$secondsLeft c')]),
+        Row(children: [Expanded(child: Text(l10n.noteDeleted)), Text('$secondsLeft ${l10n.secondsShort}')]),
         const SizedBox(height: 4),
         LinearProgressIndicator(value: value),
       ],


### PR DESCRIPTION
## Summary
- move note details strings into ARB localization files
- replace hard-coded texts with `AppLocalizations` lookups
- support current locale for note date picking

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a3e5495c8326aff72d1ff9ac4d64