### PR TITLE
Localize settings screen

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -62,5 +62,9 @@
   "dateAdded": "Date added",
   "deleteNote": "Delete note",
   "noteDeleted": "Note deleted",
-  "secondsShort": "s"
+  "secondsShort": "s",
+  "settingsTitle": "Settings",
+  "settingsLanguage": "Language",
+  "languageRussian": "Russian",
+  "languageEnglish": "English"
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -62,5 +62,9 @@
   "dateAdded": "Дата добавления",
   "deleteNote": "Удалить заметку",
   "noteDeleted": "Заметка удалена",
-  "secondsShort": "с"
+  "secondsShort": "с",
+  "settingsTitle": "Настройки",
+  "settingsLanguage": "Язык",
+  "languageRussian": "Русский",
+  "languageEnglish": "Английский"
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
+
 import '../services/locale_notifier.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -7,14 +9,15 @@ class SettingsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
     final locale = context.watch<LocaleNotifier>().locale;
     return Scaffold(
-      appBar: AppBar(title: const Text('Настройки')),
+      appBar: AppBar(title: Text(l10n.settingsTitle)),
       body: ListView(
         children: [
-          const ListTile(title: Text('Язык')),
+          ListTile(title: Text(l10n.settingsLanguage)),
           RadioListTile<Locale>(
-            title: const Text('Русский'),
+            title: Text(l10n.languageRussian),
             value: const Locale('ru'),
             groupValue: locale,
             onChanged: (value) {
@@ -24,7 +27,7 @@ class SettingsScreen extends StatelessWidget {
             },
           ),
           RadioListTile<Locale>(
-            title: const Text('English'),
+            title: Text(l10n.languageEnglish),
             value: const Locale('en'),
             groupValue: locale,
             onChanged: (value) {


### PR DESCRIPTION
## Summary
- add localization keys for the settings screen labels
- use AppLocalizations on the settings screen to show translated strings

## Testing
- flutter gen-l10n *(fails: flutter not installed in container)*


------
https://chatgpt.com/codex/tasks/task_e_68ce73380e98833188ee1c9a489f3aa9