### PR TITLE
Replace SnackBars with overlay banners

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,7 @@
 // lib/app.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:overlay_support/overlay_support.dart';
 import 'screens/home_screen.dart';
 
 class App extends StatelessWidget {
@@ -12,40 +13,42 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Touch NoteBook',
-      debugShowCheckedModeBanner: false, // 🔔 убирает "DEBUG" в углу
-      navigatorKey: navigatorKey, // <-- ВАЖНО: подключили ключ
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.deepPurple,
-          brightness: Brightness.light,
+    return OverlaySupport.global(
+      child: MaterialApp(
+        title: 'Touch NoteBook',
+        debugShowCheckedModeBanner: false, // 🔔 убирает "DEBUG" в углу
+        navigatorKey: navigatorKey, // <-- ВАЖНО: подключили ключ
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.deepPurple,
+            brightness: Brightness.light,
+          ),
+          appBarTheme: const AppBarTheme(
+            scrolledUnderElevation: 0,
+            surfaceTintColor: Colors.transparent,
+          ),
+          useMaterial3: true,
         ),
-        appBarTheme: const AppBarTheme(
-          scrolledUnderElevation: 0,
-          surfaceTintColor: Colors.transparent,
+        darkTheme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.deepPurple,
+            brightness: Brightness.dark,
+          ),
+          useMaterial3: true,
         ),
-        useMaterial3: true,
+        themeMode: ThemeMode.system,
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [
+          Locale('ru'),
+          Locale('en'),
+        ],
+        locale: const Locale('ru'),
+        home: const HomeScreen(),
       ),
-      darkTheme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.deepPurple,
-          brightness: Brightness.dark,
-        ),
-        useMaterial3: true,
-      ),
-      themeMode: ThemeMode.system,
-      localizationsDelegates: const [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: const [
-        Locale('ru'),
-        Locale('en'),
-      ],
-      locale: const Locale('ru'),
-      home: const HomeScreen(),
     );
   }
 }

--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -6,6 +6,7 @@ import 'package:characters/characters.dart';
 
 import '../models/contact.dart';
 import '../services/contact_database.dart';
+import '../widgets/system_notifications.dart';
 
 /// Словари (централизовано, без «магических» строк)
 abstract class Dict {
@@ -750,9 +751,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       Navigator.pop(context, true);
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Не удалось сохранить. Возможно, контакт с таким телефоном уже существует.')),
-      );
+      showErrorBanner('Не удалось сохранить. Возможно, контакт с таким телефоном уже существует.');
       setState(() => _saving = false);
     }
   }

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:overlay_support/overlay_support.dart';
 
 import '../app.dart'; // для App.navigatorKey
 import '../models/contact.dart';
 import '../services/contact_database.dart';
+import '../widgets/system_notifications.dart';
 import 'add_contact_screen.dart';
 import 'contact_details_screen.dart';
 import 'package:characters/characters.dart';
@@ -123,7 +125,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
   static const Duration pulseDuration = Duration(milliseconds: 3250);
 
   Timer? _debounce;
-  Timer? _snackTimer;
+  OverlaySupportEntry? _undoBanner;
   Timer? _highlightTimer;
 
   void _restoreLocally(Contact restored, {bool highlight = false}) {
@@ -180,7 +182,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
   @override
   void dispose() {
     _debounce?.cancel();
-    _snackTimer?.cancel();
+    _undoBanner?.dismiss();
     _highlightTimer?.cancel();
     _searchController.dispose();
     _scroll.removeListener(_onScroll);
@@ -274,9 +276,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
     } catch (e) {
       if (mounted) {
         setState(() => _isLoading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Ошибка загрузки контактов: $e')),
-        );
+        showErrorBanner('Ошибка загрузки контактов: $e');
       }
     }
   }
@@ -475,7 +475,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
     }
   }
 
-  /// Удаляет контакт и показывает SnackBar с Undo + индикатором и обратным отсчётом.
+  /// Удаляет контакт и показывает баннер с Undo + индикатором и обратным отсчётом.
   Future<void> _deleteWithUndo(Contact c) async {
     if (c.id == null) return;
     final db = ContactDatabase.instance;
@@ -487,35 +487,22 @@ class _ContactListScreenState extends State<ContactListScreen> {
         _all.removeWhere((e) => e.id == c.id);
         _cleanupKeys();
       });
-      // 3) Обычный (НЕ плавающий) Snackbar у нижнего края
-      if (!mounted) return;
-      final messenger = ScaffoldMessenger.of(context);
-      messenger.clearSnackBars();
-      _snackTimer?.cancel();
-      final endTime = DateTime.now().add(undoDuration);
-      final controller = messenger.showSnackBar(
-        SnackBar(
-          duration: const Duration(days: 1),
-          content: _UndoSnackContent(endTime: endTime, duration: undoDuration),
-          action: SnackBarAction(
-            label: 'Отменить',
-            onPressed: () async {
-              _snackTimer?.cancel();
-              messenger.hideCurrentSnackBar();
-              // 4) Восстанавливаем контакт + все его заметки (контакт получит НОВЫЙ id)
-              final newId = await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
-              // 5) Прокрутить/подсветить восстановленного
-              _restoreLocally(c.copyWith(id: newId), highlight: true);
-            },
-          ),
-        ),
+      // 3) Баннера с возможностью отмены
+      _undoBanner?.dismiss();
+      _undoBanner = showUndoBanner(
+        message: 'Контакт удалён',
+        duration: undoDuration,
+        icon: Icons.delete_outline,
+        onUndo: () async {
+          _undoBanner = null;
+          final newId =
+              await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+          _restoreLocally(c.copyWith(id: newId), highlight: true);
+        },
       );
-      _snackTimer = Timer(endTime.difference(DateTime.now()), () => controller.close());
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Ошибка удаления: $e')),
-        );
+        showErrorBanner('Ошибка удаления: $e');
         // Восстанавливаем локально, если удаление не прошло
         _restoreLocally(c);
       }
@@ -639,10 +626,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
           if (saved == true) {
             await _loadContacts(reset: true);
             if (mounted) {
-              // Обычный (не плавающий) Snackbar
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Контакт сохранён')),
-              );
+              showSuccessBanner('Контакт сохранён');
             }
           }
         },
@@ -1031,90 +1015,6 @@ class PositionedFill extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-/// Контент SnackBar с обратным отсчётом и прогресс-баром.
-class _UndoSnackContent extends StatefulWidget {
-  final DateTime endTime;
-  final Duration duration;
-  const _UndoSnackContent({required this.endTime, required this.duration});
-
-  @override
-  State<_UndoSnackContent> createState() => _UndoSnackContentState();
-}
-
-class _UndoSnackContentState extends State<_UndoSnackContent> with SingleTickerProviderStateMixin {
-  late AnimationController _ctrl;
-
-  double _fractionRemaining(DateTime now) {
-    final total = widget.duration.inMilliseconds;
-    final left = widget.endTime.difference(now).inMilliseconds;
-    if (total <= 0) return 0;
-    return left <= 0 ? 0 : (left / total).clamp(0.0, 1.0);
-  }
-
-  void _syncAndRun() {
-    final now = DateTime.now();
-    final frac = _fractionRemaining(now); // 0..1
-    final msLeft = (widget.duration.inMilliseconds * frac).round();
-    _ctrl.stop();
-    _ctrl.value = frac; // мгновенно, без «вспышки»
-    if (msLeft > 0) {
-      _ctrl.animateTo(
-        0.0,
-        duration: Duration(milliseconds: msLeft),
-        curve: Curves.linear,
-      );
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _ctrl = AnimationController(
-      vsync: this,
-      value: 1.0,
-      lowerBound: 0.0,
-      upperBound: 1.0,
-    )..addListener(() {
-      if (mounted) setState(() {});
-    });
-    _syncAndRun();
-  }
-
-  @override
-  void didUpdateWidget(covariant _UndoSnackContent oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.endTime != widget.endTime || oldWidget.duration != widget.duration) {
-      _syncAndRun();
-    }
-  }
-
-  @override
-  void dispose() {
-    _ctrl.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final value = _ctrl.value; // 1.0 -> 0.0
-    final secondsLeft = (value * widget.duration.inSeconds).ceil().clamp(0, 999);
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            const Expanded(child: Text('Контакт удалён')),
-            Text('$secondsLeft c'),
-          ],
-        ),
-        const SizedBox(height: 4),
-        LinearProgressIndicator(value: value),
-      ],
     );
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ import 'add_contact_screen.dart';
 import 'settings_screen.dart';
 import 'contact_list_screen.dart';
 import '../services/contact_database.dart';
+import '../widgets/system_notifications.dart';
 
 /// ---------------------
 /// Строки (русская локаль)
@@ -260,12 +261,7 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
     if (_loadErrorShown) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(R.loadError),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      showErrorBanner(R.loadError);
     });
     _loadErrorShown = true;
   }
@@ -283,34 +279,19 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
         await launchUrl(tgUri, mode: LaunchMode.externalApplication);
       } else {
         if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text(R.telegramNotInstalled),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
+        showWarningBanner(R.telegramNotInstalled);
         await launchUrl(webUri, mode: LaunchMode.externalApplication);
       }
     } catch (e, s) {
       debugPrint('openSupport error: $e\n$s');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(R.telegramOpenFailed),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      showErrorBanner(R.telegramOpenFailed);
       // мягкий fallback — скопируем ссылку
       await Clipboard.setData(
         const ClipboardData(text: 'https://t.me/touchnotebook'),
       );
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(R.linkCopied),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      showInfoBanner(R.linkCopied);
     }
   }
 
@@ -321,12 +302,7 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
       MaterialPageRoute(builder: (_) => const AddContactScreen()),
     );
     if (saved == true && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(R.contactSaved),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      showSuccessBanner(R.contactSaved);
     }
   }
 
@@ -372,12 +348,9 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
 
     // уведомляем, если ранее были неизвестные и стало меньше неизвестных
     if (last.unknownCount > 0 && newCounts.unknownCount < last.unknownCount) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(R.dataUpdated),
-          behavior: SnackBarBehavior.floating,
-          duration: Duration(milliseconds: 1500),
-        ),
+      showInfoBanner(
+        R.dataUpdated,
+        duration: const Duration(milliseconds: 1500),
       );
     }
     _lastCountsShown = newCounts;

--- a/lib/screens/note_details_screen.dart
+++ b/lib/screens/note_details_screen.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import '../app.dart'; // для App.navigatorKey
+import 'package:overlay_support/overlay_support.dart';
 import '../models/note.dart';
 import '../services/contact_database.dart';
+import '../widgets/system_notifications.dart';
 
 class NoteDetailsScreen extends StatefulWidget {
   final Note note;
@@ -23,7 +24,7 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
   DateTime _date = DateTime.now();
 
   bool _isEditing = false;
-  Timer? _snackTimer;
+  OverlaySupportEntry? _undoBanner;
 
   @override
   void initState() {
@@ -35,7 +36,7 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
   @override
   void dispose() {
     _textController.dispose();
-    _snackTimer?.cancel();
+    _undoBanner?.dismiss();
     super.dispose();
   }
 
@@ -148,13 +149,7 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
     _savedSnapshot = updated;
     setState(() => _isEditing = false);
 
-    // ✅ показываем SnackBar так, чтобы он остался после pop
-    final rootCtx = App.navigatorKey.currentContext;
-    if (rootCtx != null) {
-      ScaffoldMessenger.of(rootCtx).showSnackBar(
-        const SnackBar(content: Text('Заметка сохранена')),
-      );
-    }
+    showSuccessBanner('Заметка сохранена');
 
     if (!mounted) return;
     Navigator.pop(context, {'updated': true});
@@ -180,41 +175,30 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
     }
 
     const duration = Duration(seconds: 4);
-    final messenger = ScaffoldMessenger.of(context);
-    messenger.clearSnackBars();
-    _snackTimer?.cancel();
+    _undoBanner?.dismiss();
 
-    final endTime = DateTime.now().add(duration);
-    final controller = messenger.showSnackBar(
-      SnackBar(
-        duration: const Duration(days: 1),
-        content: _UndoSnackContentLocal(endTime: endTime, duration: duration),
-        action: SnackBarAction(
-          label: 'Отменить',
-          onPressed: () async {
-            _snackTimer?.cancel();
-            messenger.hideCurrentSnackBar();
-
-            final newId = await ContactDatabase.instance.insertNote(
-              _note.copyWith(id: null),
-            );
-            _note = _note.copyWith(id: newId);
-            _savedSnapshot = _note;
-            setState(() {
-              _isEditing = false;
-            });
-            if (mounted) {
-              Navigator.pop(context, {'restored': _note});
-            }
-          },
-        ),
-      ),
+    _undoBanner = showUndoBanner(
+      message: 'Заметка удалена',
+      duration: duration,
+      icon: Icons.delete_outline,
+      onUndo: () async {
+        _undoBanner = null;
+        final newId = await ContactDatabase.instance.insertNote(
+          _note.copyWith(id: null),
+        );
+        _note = _note.copyWith(id: newId);
+        _savedSnapshot = _note;
+        if (!mounted) return;
+        setState(() {
+          _isEditing = false;
+        });
+        Navigator.pop(context, {'restored': _note});
+      },
     );
-
-    _snackTimer = Timer(endTime.difference(DateTime.now()), () => controller.close());
 
     Future.delayed(duration, () {
       if (mounted) {
+        _undoBanner = null;
         Navigator.pop(context, {'deleted': _note});
       }
     });
@@ -309,79 +293,3 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
   }
 }
 
-/// Локальный контент SnackBar с обратным отсчётом (экран деталей заметки)
-class _UndoSnackContentLocal extends StatefulWidget {
-  final DateTime endTime;
-  final Duration duration;
-  const _UndoSnackContentLocal({required this.endTime, required this.duration});
-
-  @override
-  State<_UndoSnackContentLocal> createState() => _UndoSnackContentLocalState();
-}
-
-class _UndoSnackContentLocalState extends State<_UndoSnackContentLocal>
-    with SingleTickerProviderStateMixin {
-  late AnimationController _ctrl;
-
-  double _fractionRemaining(DateTime now) {
-    final total = widget.duration.inMilliseconds;
-    final left = widget.endTime.difference(now).inMilliseconds;
-    if (total <= 0) return 0;
-    return left <= 0 ? 0 : (left / total).clamp(0.0, 1.0);
-  }
-
-  void _syncAndRun() {
-    final now = DateTime.now();
-    final frac = _fractionRemaining(now);
-    final msLeft = (widget.duration.inMilliseconds * frac).round();
-
-    _ctrl.stop();
-    _ctrl.value = frac;
-    if (msLeft > 0) {
-      _ctrl.animateTo(0.0, duration: Duration(milliseconds: msLeft), curve: Curves.linear);
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _ctrl = AnimationController(
-      vsync: this,
-      value: 1.0,
-      lowerBound: 0.0,
-      upperBound: 1.0,
-    )..addListener(() {
-      if (mounted) setState(() {});
-    });
-    _syncAndRun();
-  }
-
-  @override
-  void didUpdateWidget(covariant _UndoSnackContentLocal oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.endTime != widget.endTime || oldWidget.duration != widget.duration) {
-      _syncAndRun();
-    }
-  }
-
-  @override
-  void dispose() {
-    _ctrl.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final value = _ctrl.value;
-    final secondsLeft = (value * widget.duration.inSeconds).ceil().clamp(0, 999);
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(children: [const Expanded(child: Text('Заметка удалена')), Text('$secondsLeft c')]),
-        const SizedBox(height: 4),
-        LinearProgressIndicator(value: value),
-      ],
-    );
-  }
-}

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:overlay_support/overlay_support.dart';
 
 import '../models/contact.dart';
 import '../models/note.dart';
 import '../services/contact_database.dart';
 import 'add_note_screen.dart';
 import 'note_details_screen.dart';
+import '../widgets/system_notifications.dart';
 
 class NotesListScreen extends StatefulWidget {
   final Contact contact;
@@ -35,7 +37,7 @@ class _NotesListScreenState extends State<NotesListScreen> {
   final Map<int, GlobalKey> _itemKeys = {};
   int? _highlightId;
   int _pulseSeed = 0;
-  Timer? _snackTimer;
+  OverlaySupportEntry? _undoBanner;
 
   @override
   void initState() {
@@ -48,7 +50,7 @@ class _NotesListScreenState extends State<NotesListScreen> {
   void dispose() {
     _scroll.removeListener(_onScroll);
     _scroll.dispose();
-    _snackTimer?.cancel();
+    _undoBanner?.dismiss();
     super.dispose();
   }
 
@@ -197,8 +199,7 @@ class _NotesListScreenState extends State<NotesListScreen> {
     if (note != null) {
       await _loadNotes(reset: true);
       if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Заметка добавлена')));
+      showSuccessBanner('Заметка добавлена');
       // скролл и подсветка новой заметки (если у неё есть id)
       if (note.id != null) {
         await _maybeScrollTo(note.id!);
@@ -243,36 +244,22 @@ class _NotesListScreenState extends State<NotesListScreen> {
     setState(() => _notes.removeWhere((e) => e.id == n.id));
 
     if (!mounted) return;
-    final messenger = ScaffoldMessenger.of(context);
     const duration = Duration(seconds: 4);
+    _undoBanner?.dismiss();
 
-    messenger.clearSnackBars();
-    _snackTimer?.cancel();
-
-    final endTime = DateTime.now().add(duration);
-    final controller = messenger.showSnackBar(
-      SnackBar(
-        duration: const Duration(days: 1),
-        content: _UndoSnackContentNote(endTime: endTime, duration: duration),
-        action: SnackBarAction(
-          label: 'Отменить',
-          onPressed: () async {
-            _snackTimer?.cancel();
-            messenger.hideCurrentSnackBar();
-
-            final id = await _db.insertNote(n.copyWith(id: null));
-            await _loadNotes(reset: true);
-            if (!mounted) return;
-
-            await _maybeScrollTo(id);
-            _flashHighlight(id);
-          },
-        ),
-      ),
+    _undoBanner = showUndoBanner(
+      message: 'Заметка удалена',
+      duration: duration,
+      icon: Icons.delete_outline,
+      onUndo: () async {
+        _undoBanner = null;
+        final id = await _db.insertNote(n.copyWith(id: null));
+        await _loadNotes(reset: true);
+        if (!mounted) return;
+        await _maybeScrollTo(id);
+        _flashHighlight(id);
+      },
     );
-
-    _snackTimer =
-        Timer(endTime.difference(DateTime.now()), () => controller.close());
   }
 
   Future<void> _showNoteMenu(Note n) async {
@@ -529,82 +516,3 @@ class _NoteCardState extends State<_NoteCard> with TickerProviderStateMixin {
   }
 }
 
-/// Контент SnackBar с обратным отсчётом (для заметок)
-class _UndoSnackContentNote extends StatefulWidget {
-  final DateTime endTime;
-  final Duration duration;
-  const _UndoSnackContentNote({required this.endTime, required this.duration});
-
-  @override
-  State<_UndoSnackContentNote> createState() => _UndoSnackContentNoteState();
-}
-
-class _UndoSnackContentNoteState extends State<_UndoSnackContentNote>
-    with SingleTickerProviderStateMixin {
-  late AnimationController _ctrl;
-
-  double _fractionRemaining(DateTime now) {
-    final total = widget.duration.inMilliseconds;
-    final left = widget.endTime.difference(now).inMilliseconds;
-    if (total <= 0) return 0;
-    return left <= 0 ? 0 : (left / total).clamp(0.0, 1.0);
-  }
-
-  void _syncAndRun() {
-    final now = DateTime.now();
-    final frac = _fractionRemaining(now);
-    final msLeft = (widget.duration.inMilliseconds * frac).round();
-
-    _ctrl.stop();
-    _ctrl.value = frac;
-    if (msLeft > 0) {
-      _ctrl.animateTo(0.0,
-          duration: Duration(milliseconds: msLeft), curve: Curves.linear);
-    }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _ctrl = AnimationController(
-      vsync: this,
-      value: 1.0,
-      lowerBound: 0.0,
-      upperBound: 1.0,
-    )..addListener(() {
-      if (mounted) setState(() {});
-    });
-    _syncAndRun();
-  }
-
-  @override
-  void didUpdateWidget(covariant _UndoSnackContentNote oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.endTime != widget.endTime ||
-        oldWidget.duration != widget.duration) {
-      _syncAndRun();
-    }
-  }
-
-  @override
-  void dispose() {
-    _ctrl.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final value = _ctrl.value;
-    final secondsLeft =
-    (value * widget.duration.inSeconds).ceil().clamp(0, 999);
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(children: [const Expanded(child: Text('Заметка удалена')), Text('$secondsLeft c')]),
-        const SizedBox(height: 4),
-        LinearProgressIndicator(value: value),
-      ],
-    );
-  }
-}

--- a/lib/widgets/system_notifications.dart
+++ b/lib/widgets/system_notifications.dart
@@ -1,0 +1,365 @@
+import 'package:flutter/material.dart';
+import 'package:overlay_support/overlay_support.dart';
+
+enum SystemNotificationStyle { info, success, warning, error }
+
+OverlaySupportEntry showSystemNotification(
+  String message, {
+  SystemNotificationStyle style = SystemNotificationStyle.info,
+  Duration duration = const Duration(seconds: 3),
+  String? actionLabel,
+  Future<void> Function()? onAction,
+  IconData? iconOverride,
+}) {
+  return showOverlayNotification(
+    (context) {
+      final entry = OverlaySupportEntry.of(context);
+      final colors = _resolveColors(style, Theme.of(context));
+      final icon = iconOverride ?? colors.icon;
+      final action = (actionLabel != null && onAction != null)
+          ? TextButton(
+              onPressed: () async {
+                entry?.dismiss();
+                await onAction();
+              },
+              style: TextButton.styleFrom(
+                foregroundColor: colors.foreground,
+                textStyle: const TextStyle(fontWeight: FontWeight.w600),
+              ),
+              child: Text(actionLabel),
+            )
+          : null;
+
+      return _SystemNotificationSurface(
+        backgroundColor: colors.background,
+        textColor: colors.foreground,
+        icon: icon,
+        iconColor: colors.iconColor,
+        content: Text(
+          message,
+          maxLines: 3,
+          overflow: TextOverflow.ellipsis,
+        ),
+        action: action,
+      );
+    },
+    duration: duration,
+  );
+}
+
+OverlaySupportEntry showInfoBanner(
+  String message, {
+  Duration duration = const Duration(seconds: 3),
+}) =>
+    showSystemNotification(
+      message,
+      style: SystemNotificationStyle.info,
+      duration: duration,
+    );
+
+OverlaySupportEntry showSuccessBanner(
+  String message, {
+  Duration duration = const Duration(seconds: 3),
+}) =>
+    showSystemNotification(
+      message,
+      style: SystemNotificationStyle.success,
+      duration: duration,
+    );
+
+OverlaySupportEntry showWarningBanner(
+  String message, {
+  Duration duration = const Duration(seconds: 3),
+}) =>
+    showSystemNotification(
+      message,
+      style: SystemNotificationStyle.warning,
+      duration: duration,
+    );
+
+OverlaySupportEntry showErrorBanner(
+  String message, {
+  Duration duration = const Duration(seconds: 4),
+}) =>
+    showSystemNotification(
+      message,
+      style: SystemNotificationStyle.error,
+      duration: duration,
+    );
+
+OverlaySupportEntry showUndoBanner({
+  required String message,
+  required Duration duration,
+  required Future<void> Function() onUndo,
+  IconData icon = Icons.undo,
+  SystemNotificationStyle style = SystemNotificationStyle.warning,
+  String actionLabel = 'Отменить',
+}) {
+  final endTime = DateTime.now().add(duration);
+  return showOverlayNotification(
+    (context) {
+      final entry = OverlaySupportEntry.of(context);
+      final colors = _resolveColors(style, Theme.of(context));
+      return _SystemNotificationSurface(
+        backgroundColor: colors.background,
+        textColor: colors.foreground,
+        icon: icon,
+        iconColor: colors.iconColor,
+        content: UndoCountdownContent(
+          message: message,
+          endTime: endTime,
+          duration: duration,
+          progressColor: colors.iconColor,
+          trackColor: colors.foreground.withOpacity(0.2),
+        ),
+        action: TextButton(
+          onPressed: () async {
+            entry?.dismiss();
+            await onUndo();
+          },
+          style: TextButton.styleFrom(
+            foregroundColor: colors.foreground,
+            textStyle: const TextStyle(fontWeight: FontWeight.w600),
+          ),
+          child: Text(actionLabel),
+        ),
+      );
+    },
+    duration: duration,
+  );
+}
+
+class UndoCountdownContent extends StatefulWidget {
+  final String message;
+  final DateTime endTime;
+  final Duration duration;
+  final Color? progressColor;
+  final Color? trackColor;
+
+  const UndoCountdownContent({
+    super.key,
+    required this.message,
+    required this.endTime,
+    required this.duration,
+    this.progressColor,
+    this.trackColor,
+  });
+
+  @override
+  State<UndoCountdownContent> createState() => _UndoCountdownContentState();
+}
+
+class _UndoCountdownContentState extends State<UndoCountdownContent>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  double _fractionRemaining(DateTime now) {
+    final total = widget.duration.inMilliseconds;
+    if (total <= 0) return 0;
+    final left = widget.endTime.difference(now).inMilliseconds;
+    if (left <= 0) return 0;
+    return (left / total).clamp(0.0, 1.0);
+  }
+
+  void _syncAndRun() {
+    final now = DateTime.now();
+    final fraction = _fractionRemaining(now);
+    final remainingMs = (widget.duration.inMilliseconds * fraction).round();
+
+    _controller.stop();
+    _controller.value = fraction;
+    if (remainingMs > 0) {
+      _controller.animateTo(
+        0.0,
+        duration: Duration(milliseconds: remainingMs),
+        curve: Curves.linear,
+      );
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      value: 1.0,
+      lowerBound: 0.0,
+      upperBound: 1.0,
+    )..addListener(() {
+        if (mounted) setState(() {});
+      });
+    _syncAndRun();
+  }
+
+  @override
+  void didUpdateWidget(covariant UndoCountdownContent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.endTime != widget.endTime ||
+        oldWidget.duration != widget.duration) {
+      _syncAndRun();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final value = _controller.value;
+    final secondsLeft = (value * widget.duration.inSeconds).ceil().clamp(0, 999);
+    final progressColor = widget.progressColor ?? Theme.of(context).colorScheme.primary;
+    final trackColor = widget.trackColor ?? progressColor.withOpacity(0.2);
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(child: Text(widget.message)),
+            Text('$secondsLeft c'),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(999),
+          child: LinearProgressIndicator(
+            value: value,
+            minHeight: 4,
+            color: progressColor,
+            backgroundColor: trackColor,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SystemNotificationSurface extends StatelessWidget {
+  final Widget content;
+  final IconData? icon;
+  final Color? iconColor;
+  final Color backgroundColor;
+  final Color textColor;
+  final Widget? action;
+
+  const _SystemNotificationSurface({
+    required this.content,
+    required this.backgroundColor,
+    required this.textColor,
+    this.icon,
+    this.iconColor,
+    this.action,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final baseStyle = theme.textTheme.bodyMedium ?? const TextStyle(fontSize: 14);
+    final textStyle = baseStyle.copyWith(color: textColor);
+
+    final children = <Widget>[];
+    if (icon != null) {
+      children
+        ..add(Icon(icon, color: iconColor ?? textColor))
+        ..add(const SizedBox(width: 12));
+    }
+    children.add(Expanded(child: content));
+    if (action != null) {
+      children
+        ..add(const SizedBox(width: 12))
+        ..add(action!);
+    }
+
+    return SafeArea(
+      minimum: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Material(
+          color: Colors.transparent,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: backgroundColor,
+              borderRadius: BorderRadius.circular(18),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.08),
+                  blurRadius: 24,
+                  offset: const Offset(0, 12),
+                ),
+              ],
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              child: DefaultTextStyle(
+                style: textStyle,
+                child: IconTheme.merge(
+                  data: IconThemeData(color: iconColor ?? textColor),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: children,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SystemNotificationColors {
+  final IconData icon;
+  final Color background;
+  final Color foreground;
+  final Color iconColor;
+
+  const _SystemNotificationColors({
+    required this.icon,
+    required this.background,
+    required this.foreground,
+    required this.iconColor,
+  });
+}
+
+_SystemNotificationColors _resolveColors(
+  SystemNotificationStyle style,
+  ThemeData theme,
+) {
+  final scheme = theme.colorScheme;
+  switch (style) {
+    case SystemNotificationStyle.success:
+      return _SystemNotificationColors(
+        icon: Icons.check_circle_outline,
+        background: scheme.primaryContainer,
+        foreground: scheme.onPrimaryContainer,
+        iconColor: scheme.onPrimaryContainer,
+      );
+    case SystemNotificationStyle.warning:
+      return _SystemNotificationColors(
+        icon: Icons.warning_amber_rounded,
+        background: scheme.tertiaryContainer,
+        foreground: scheme.onTertiaryContainer,
+        iconColor: scheme.onTertiaryContainer,
+      );
+    case SystemNotificationStyle.error:
+      return _SystemNotificationColors(
+        icon: Icons.error_outline,
+        background: scheme.errorContainer,
+        foreground: scheme.onErrorContainer,
+        iconColor: scheme.onErrorContainer,
+      );
+    case SystemNotificationStyle.info:
+    default:
+      return _SystemNotificationColors(
+        icon: Icons.info_outline,
+        background: scheme.surface,
+        foreground: scheme.onSurface,
+        iconColor: scheme.primary,
+      );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   path_provider: ^2.1.2
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
+  overlay_support: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- wrap the app with OverlaySupport and add reusable system notification helpers for banner-style alerts
- switch SnackBar usages across the UI to the new overlay banners, including undo flows with countdowns

## Testing
- unable to run flutter pub get (flutter command not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceee7ff2fc8331af6d2f16f58f5922