### PR TITLE
Ensure contact details notes reflect undo restores

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1666,7 +1666,10 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                           await Navigator.push(
                             context,
                             MaterialPageRoute(
-                              builder: (_) => NotesListScreen(contact: _contact),
+                              builder: (_) => NotesListScreen(
+                                contact: _contact,
+                                onNoteRestored: (_) => _loadNotes(),
+                              ),
                             ),
                           );
                           await _loadNotes();


### PR DESCRIPTION
## Summary
- add an optional callback to `NotesListScreen` to notify when a note is restored
- reload the notes block on the contact details screen when a restoration happens after returning from the notes list
- guard undo restoration logic so the callback fires even if the list screen is no longer mounted

## Testing
- Not run (Flutter SDK is unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68d4270134dc8328adda75a2362d2a69