### PR TITLE
Fix notes refresh behavior and adjust empty notes state

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1653,38 +1653,56 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     setState(() => _notesExpanded = v);
                     if (v) _scrollToCard(_notesCardKey);
                   },
-                  headerActions: [
+                  headerActions: _notes.isNotEmpty
+                      ? [
                     const Spacer(),
-                    if (_notes.isEmpty)
-                      TextButton.icon(
-                        onPressed: _contact.id == null ? null : _addNote,
-                        label: const Text('Добавить заметку'),
-                      )
-                    else
-                      TextButton(
-                        onPressed: () async {
-                          if (_contact.id == null) return;
-                          await Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => NotesListScreen(
-                                contact: _contact,
-                                onNoteRestored: (_) => _loadNotes(),
-                              ),
+                    TextButton(
+                      onPressed: () async {
+                        if (_contact.id == null) return;
+                        await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => NotesListScreen(
+                              contact: _contact,
+                              onNoteRestored: (_) => _loadNotes(),
                             ),
-                          );
-                          await _loadNotes();
-                        },
-                        child: const Text('Все заметки'),
-                      ),
-                  ],
+                          ),
+                        );
+                        await _loadNotes();
+                      },
+                      child: const Text('Все заметки'),
+                    ),
+                  ]
+                      : const [],
                   children: _notes.isEmpty
-                      ? const [
+                      ? [
                     Card(
                       elevation: 0,
-                      child: ListTile(
-                        leading: Icon(Icons.sticky_note_2_outlined),
-                        title: Text('Нет заметок'),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 24, horizontal: 16),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.sticky_note_2_outlined,
+                              size: 40,
+                              color: Theme.of(context).hintColor,
+                            ),
+                            const SizedBox(height: 12),
+                            const Text(
+                              'Нет заметок',
+                              textAlign: TextAlign.center,
+                            ),
+                            const SizedBox(height: 20),
+                            ElevatedButton.icon(
+                              onPressed: _contact.id == null ? null : _addNote,
+                              icon: const Icon(Icons.add),
+                              label: const Text('Добавить заметку'),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ]


### PR DESCRIPTION
## Summary
- avoid clearing the notes list immediately during a pull-to-refresh so the screen no longer flashes empty content while the data reloads
- refresh the empty notes section on the contact details screen by centering the placeholder message and moving the add button into the card while keeping the "Все заметки" action for non-empty lists

## Testing
- `flutter analyze` *(fails: Flutter SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d431516d948328a5258cd0e9d86c01