### PR TITLE
Improve notes refresh behavior and empty state

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1655,36 +1655,51 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                   },
                   headerActions: [
                     const Spacer(),
-                    if (_notes.isEmpty)
-                      TextButton.icon(
-                        onPressed: _contact.id == null ? null : _addNote,
-                        label: const Text('Добавить заметку'),
-                      )
-                    else
-                      TextButton(
-                        onPressed: () async {
-                          if (_contact.id == null) return;
-                          await Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => NotesListScreen(
-                                contact: _contact,
-                                onNoteRestored: (_) => _loadNotes(),
-                              ),
-                            ),
-                          );
-                          await _loadNotes();
-                        },
-                        child: const Text('Все заметки'),
-                      ),
+                    TextButton(
+                      onPressed: _contact.id == null
+                          ? null
+                          : () async {
+                              await Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) => NotesListScreen(
+                                    contact: _contact,
+                                    onNoteRestored: (_) => _loadNotes(),
+                                  ),
+                                ),
+                              );
+                              await _loadNotes();
+                            },
+                      child: const Text('Все заметки'),
+                    ),
                   ],
                   children: _notes.isEmpty
-                      ? const [
+                      ? [
                     Card(
                       elevation: 0,
-                      child: ListTile(
-                        leading: Icon(Icons.sticky_note_2_outlined),
-                        title: Text('Нет заметок'),
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(
+                              Icons.sticky_note_2_outlined,
+                              size: 48,
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              'Нет заметок',
+                              style: Theme.of(context).textTheme.titleMedium,
+                              textAlign: TextAlign.center,
+                            ),
+                            const SizedBox(height: 24),
+                            FilledButton.icon(
+                              onPressed: _contact.id == null ? null : _addNote,
+                              icon: const Icon(Icons.add),
+                              label: const Text('Добавить заметку'),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ]

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -71,15 +71,11 @@ class _NotesListScreenState extends State<NotesListScreen> {
 
   Future<void> _loadNotes({bool reset = false}) async {
     if (reset) {
-      setState(() {
-        _notes.clear();
-        _sortedNotes = const [];
-        _page = 0;
-        _hasMore = true;
-        _itemKeys.clear();
-      });
+      _page = 0;
+      _hasMore = true;
+      _itemKeys.clear();
     }
-    await _loadMoreNotes();
+    await _loadMoreNotes(reset: reset);
   }
 
   void _onScroll() {
@@ -88,8 +84,9 @@ class _NotesListScreenState extends State<NotesListScreen> {
     }
   }
 
-  Future<void> _loadMoreNotes() async {
-    if (widget.contact.id == null || _isLoading || !_hasMore) return;
+  Future<void> _loadMoreNotes({bool reset = false}) async {
+    if (widget.contact.id == null || _isLoading) return;
+    if (!reset && !_hasMore) return;
 
     setState(() => _isLoading = true);
 
@@ -107,13 +104,20 @@ class _NotesListScreenState extends State<NotesListScreen> {
     if (!mounted) return;
 
     setState(() {
-      final existingIds = _notes.map((e) => e.id).toSet();
-      final unique = pageNotes.where((n) => !existingIds.contains(n.id)).toList();
+      if (reset) {
+        _notes = [...pageNotes];
+        _page = 1;
+        _hasMore = pageNotes.length >= _pageSize;
+      } else {
+        final existingIds = _notes.map((e) => e.id).toSet();
+        final unique =
+            pageNotes.where((n) => !existingIds.contains(n.id)).toList();
 
-      _notes.addAll(unique);
-      _page++;
+        _notes.addAll(unique);
+        _page++;
+        if (pageNotes.length < _pageSize) _hasMore = false;
+      }
       _isLoading = false;
-      if (pageNotes.length < _pageSize) _hasMore = false;
 
       _rebuildSorted();
     });


### PR DESCRIPTION
## Summary
- keep the notes list intact during pull-to-refresh by reworking the paging reset logic
- centralize the empty notes message in contact details and move the add button below it while retaining quick access to the full list

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d439ee2c90832888ae558b7e785fcd