### PR TITLE
Fix note deletion flow and disable contact note opening

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -6,15 +6,12 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:characters/characters.dart';
 import 'package:overlay_support/overlay_support.dart';
 
-
-import '../app.dart'; // для App.navigatorKey (глобальная навигация)
 import '../models/contact.dart';
 import '../models/note.dart';
 import '../services/contact_database.dart';
 import '../widgets/system_notifications.dart';
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
-import 'note_details_screen.dart';
 import 'contact_list_screen.dart';
 
 class ContactDetailsScreen extends StatefulWidget {
@@ -87,7 +84,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
           ),
         ],
       ),
-      onTap: () => _openNote(note),
+      onTap: null,
       isLast: isLast,
     );
   }
@@ -95,7 +92,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   Widget _sheetRow({
     required Widget leading,
     required Widget right,
-    required VoidCallback onTap,
+    VoidCallback? onTap,
     bool isLast = false,
   }) {
     final theme = Theme.of(context);
@@ -601,36 +598,6 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       await _loadNotes();
       if (!mounted) return;
       showSuccessBanner('Заметка добавлена');
-    }
-  }
-
-  Future<void> _openNote(Note note) async {
-    final result = await Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => NoteDetailsScreen(note: note)),
-    );
-
-    if (result is Map && result['deleted'] is Note) {
-      final deleted = result['deleted'] as Note;
-      await _loadNotes();
-      if (!mounted) return;
-      showSystemNotification(
-        'Заметка удалена',
-        style: SystemNotificationStyle.warning,
-        iconOverride: Icons.delete_outline,
-        actionLabel: 'Undo',
-        onAction: () async {
-          final id = await ContactDatabase.instance
-              .insertNote(deleted.copyWith(id: null));
-          await _loadNotes();
-          if (!mounted) return;
-          final restored = deleted.copyWith(id: id);
-          Navigator.push(
-            context,
-            MaterialPageRoute(builder: (_) => NoteDetailsScreen(note: restored)),
-          );
-        },
-      );
     }
   }
 

--- a/lib/screens/note_details_screen.dart
+++ b/lib/screens/note_details_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:overlay_support/overlay_support.dart';
 import '../models/note.dart';
 import '../services/contact_database.dart';
 import '../widgets/system_notifications.dart';
@@ -24,8 +23,6 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
   DateTime _date = DateTime.now();
 
   bool _isEditing = false;
-  OverlaySupportEntry? _undoBanner;
-
   @override
   void initState() {
     super.initState();
@@ -36,8 +33,6 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
   @override
   void dispose() {
     _textController.dispose();
-    _undoBanner = null;
-    _undoBanner?.dismiss();
     super.dispose();
   }
 
@@ -175,34 +170,9 @@ class _NoteDetailsScreenState extends State<NoteDetailsScreen>
       await ContactDatabase.instance.deleteNote(_note.id!);
     }
 
-    const duration = Duration(seconds: 4);
-    _undoBanner?.dismiss();
+    if (!mounted) return;
 
-    _undoBanner = showUndoBanner(
-      message: 'Заметка удалена',
-      duration: duration,
-      icon: Icons.delete_outline,
-      onUndo: () async {
-        _undoBanner = null;
-        final newId = await ContactDatabase.instance.insertNote(
-          _note.copyWith(id: null),
-        );
-        _note = _note.copyWith(id: newId);
-        _savedSnapshot = _note;
-        if (!mounted) return;
-        setState(() {
-          _isEditing = false;
-        });
-        Navigator.pop(context, {'restored': _note});
-      },
-    );
-
-    Future.delayed(duration, () {
-      if (mounted) {
-        _undoBanner = null;
-        Navigator.pop(context, {'deleted': _note});
-      }
-    });
+    Navigator.pop(context, {'deleted': _note});
   }
 
   @override


### PR DESCRIPTION
## Summary
- remove the ability to open a note preview from the contact details screen
- close the note details screen immediately after deletion and return the deleted note
- reuse the shared undo banner flow in the notes list when a note is deleted from its details screen

## Testing
- Not run (flutter tool is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4439f1088832884a993be46fa3890