### PR TITLE
Refactor home and add contact screens for better separation of concerns

### DIFF
--- a/lib/screens/add_contact/add_contact_controller.dart
+++ b/lib/screens/add_contact/add_contact_controller.dart
@@ -1,0 +1,409 @@
+part of add_contact_screen;
+
+class AddContactFormController extends ChangeNotifier {
+  AddContactFormController({String? initialCategory}) {
+    if (initialCategory != null) {
+      _category = initialCategory;
+      categoryController.text = initialCategory;
+    }
+    _addedDate = DateTime.now();
+    addedController.text = DateFormat('dd.MM.yyyy').format(_addedDate);
+    _attachListeners();
+  }
+
+  final formKey = GlobalKey<FormState>();
+  final scrollController = ScrollController();
+
+  final GlobalKey nameKey = GlobalKey();
+  final GlobalKey phoneKey = GlobalKey();
+  final GlobalKey categoryKey = GlobalKey();
+  final GlobalKey statusKey = GlobalKey();
+  final GlobalKey addedKey = GlobalKey();
+  final GlobalKey extraCardKey = GlobalKey();
+
+  final TextEditingController nameController = TextEditingController();
+  final TextEditingController birthController = TextEditingController();
+  final TextEditingController professionController = TextEditingController();
+  final TextEditingController cityController = TextEditingController();
+  final TextEditingController phoneController = TextEditingController();
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController socialController = TextEditingController();
+  final TextEditingController categoryController = TextEditingController();
+  final TextEditingController statusController = TextEditingController();
+  final TextEditingController commentController = TextEditingController();
+  final TextEditingController addedController = TextEditingController();
+
+  final FocusNode focusBirth = FocusNode(skipTraversal: true);
+  final FocusNode focusSocial = FocusNode(skipTraversal: true);
+  final FocusNode focusCategory = FocusNode(skipTraversal: true);
+  final FocusNode focusStatus = FocusNode(skipTraversal: true);
+  final FocusNode focusAdded = FocusNode(skipTraversal: true);
+
+  final MaskTextInputFormatter phoneMask = MaskTextInputFormatter(
+    mask: '+7 (###) ###-##-##',
+    filter: {'#': RegExp(r'[0-9]')},
+  );
+
+  bool submitted = false;
+  bool saving = false;
+
+  DateTime? _birthDate;
+  int? _ageManual;
+  String? _category;
+  String? _status;
+  DateTime _addedDate = DateTime.now();
+  final Set<String> _tags = <String>{};
+
+  bool birthOpen = false;
+  bool socialOpen = false;
+  bool categoryOpen = false;
+  bool statusOpen = false;
+  bool addedOpen = false;
+  bool extraExpanded = false;
+
+  DateTime? get birthDate => _birthDate;
+  int? get ageManual => _ageManual;
+  String? get category => _category;
+  String? get status => _status;
+  DateTime get addedDate => _addedDate;
+  Set<String> get tags => _tags;
+
+  bool get phoneValid => phoneMask.getUnmaskedText().length == 10;
+
+  bool get canSave =>
+      nameController.text.trim().isNotEmpty &&
+      phoneValid &&
+      _category != null &&
+      _status != null &&
+      addedController.text.trim().isNotEmpty &&
+      !saving;
+
+  void _attachListeners() {
+    final listeners = [
+      nameController,
+      phoneController,
+      emailController,
+      professionController,
+      cityController,
+      commentController,
+      socialController,
+      categoryController,
+      statusController,
+      addedController,
+      birthController,
+    ];
+    for (final c in listeners) {
+      c.addListener(notifyListeners);
+    }
+
+    focusCategory.addListener(notifyListeners);
+    focusStatus.addListener(notifyListeners);
+    focusSocial.addListener(notifyListeners);
+    focusBirth.addListener(notifyListeners);
+    focusAdded.addListener(notifyListeners);
+  }
+
+  Future<void> scrollToCard(GlobalKey key) async {
+    final ctx = key.currentContext;
+    if (ctx == null) return;
+    await Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 350),
+      curve: Curves.easeOut,
+      alignment: 0.1,
+    );
+  }
+
+  void setSubmitted(bool value) {
+    if (submitted == value) return;
+    submitted = value;
+    notifyListeners();
+  }
+
+  void setSaving(bool value) {
+    if (saving == value) return;
+    saving = value;
+    notifyListeners();
+  }
+
+  void setBirthOpen(bool value) {
+    if (birthOpen == value) return;
+    birthOpen = value;
+    notifyListeners();
+  }
+
+  void setSocialOpen(bool value) {
+    if (socialOpen == value) return;
+    socialOpen = value;
+    notifyListeners();
+  }
+
+  void setCategoryOpen(bool value) {
+    if (categoryOpen == value) return;
+    categoryOpen = value;
+    notifyListeners();
+  }
+
+  void setStatusOpen(bool value) {
+    if (statusOpen == value) return;
+    statusOpen = value;
+    notifyListeners();
+  }
+
+  void setAddedOpen(bool value) {
+    if (addedOpen == value) return;
+    addedOpen = value;
+    notifyListeners();
+  }
+
+  void toggleExtraExpanded() {
+    setExtraExpanded(!extraExpanded);
+  }
+
+  void setExtraExpanded(bool value) {
+    if (extraExpanded == value) return;
+    extraExpanded = value;
+    notifyListeners();
+  }
+
+  void setBirthDate(DateTime? value) {
+    _birthDate = value;
+    if (value != null) {
+      final formatted = DateFormat('dd.MM.yyyy').format(value);
+      final age = calcAge(value);
+      birthController.text = '$formatted (${formatAge(age)})';
+      _ageManual = null;
+    } else {
+      birthController.clear();
+    }
+    notifyListeners();
+  }
+
+  void setAgeManual(int? value) {
+    _ageManual = value;
+    if (value != null) {
+      birthController.text = 'Возраст: ${formatAge(value)}';
+      _birthDate = null;
+    } else {
+      birthController.clear();
+    }
+    notifyListeners();
+  }
+
+  void setCategory(String? value) {
+    _category = value;
+    categoryController.text = value ?? '';
+    notifyListeners();
+  }
+
+  void setStatus(String? value) {
+    _status = value;
+    statusController.text = value ?? '';
+    notifyListeners();
+  }
+
+  void updateAddedDate(DateTime value) {
+    _addedDate = value;
+    addedController.text = DateFormat('dd.MM.yyyy').format(value);
+    notifyListeners();
+  }
+
+  void toggleTag(String tag) {
+    if (_tags.contains(tag)) {
+      _tags.remove(tag);
+    } else {
+      _tags.add(tag);
+    }
+    notifyListeners();
+  }
+
+  String previewPhoneMasked() {
+    final digits = phoneMask.getUnmaskedText();
+    const mask = '+7 (XXX) XXX-XX-XX';
+    final buf = StringBuffer();
+    var di = 0;
+    for (var i = 0; i < mask.length; i++) {
+      final ch = mask[i];
+      if (ch == 'X') {
+        if (di < digits.length) {
+          buf.write(digits[di]);
+          di++;
+        } else {
+          buf.write('X');
+        }
+      } else {
+        buf.write(ch);
+      }
+    }
+    return buf.toString();
+  }
+
+  int calcAge(DateTime birth) {
+    final now = DateTime.now();
+    var age = now.year - birth.year;
+    if (now.month < birth.month || (now.month == birth.month && now.day < birth.day)) {
+      age--;
+    }
+    return age;
+  }
+
+  String formatAge(int age) {
+    final lastTwo = age % 100;
+    final last = age % 10;
+    if (lastTwo >= 11 && lastTwo <= 14) return '$age лет';
+    if (last == 1) return '$age год';
+    if (last >= 2 && last <= 4) return '$age года';
+    return '$age лет';
+  }
+
+  String initials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+')).where((e) => e.isNotEmpty).toList();
+    if (parts.isEmpty) return '';
+    if (parts.length == 1) {
+      return parts.first.characters.take(2).toString().toUpperCase();
+    }
+    final first = parts.first.characters.take(1).toString();
+    final second = parts[1].characters.take(1).toString();
+    return (first + second).toUpperCase();
+  }
+
+  Color avatarBgFor(String seed, ColorScheme scheme) {
+    var h = 0;
+    for (final r in seed.runes) {
+      h = (h * 31 + r) & 0x7fffffff;
+    }
+    final hue = (h % 360).toDouble();
+    final hsl = HSLColor.fromAHSL(1.0, hue, 0.45, 0.55);
+    return hsl.toColor();
+  }
+
+  IconData statusIcon(String status) {
+    switch (status) {
+      case 'Активный':
+        return Icons.check_circle;
+      case 'Пассивный':
+        return Icons.pause_circle;
+      case 'Потерянный':
+        return Icons.cancel;
+      case 'Холодный':
+        return Icons.ac_unit;
+      case 'Тёплый':
+        return Icons.local_fire_department;
+      default:
+        return Icons.label_outline;
+    }
+  }
+
+  IconData categoryIcon(String? category) {
+    switch (category) {
+      case 'Партнёр':
+        return Icons.handshake;
+      case 'Клиент':
+        return Icons.people;
+      case 'Потенциальный':
+        return Icons.person_add_alt_1;
+      default:
+        return Icons.person_outline;
+    }
+  }
+
+  Color statusColor(String status) {
+    switch (status) {
+      case 'Активный':
+        return Colors.green;
+      case 'Пассивный':
+        return Colors.orange;
+      case 'Потерянный':
+        return Colors.red;
+      case 'Холодный':
+        return Colors.cyan;
+      case 'Тёплый':
+        return Colors.pink;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  Color onStatus(Color bg) {
+    final brightness = bg.computeLuminance();
+    return brightness > 0.5 ? Colors.black : Colors.white;
+  }
+
+  Color tagColor(String tag) {
+    switch (tag) {
+      case 'Новый':
+        return Colors.white;
+      case 'Напомнить':
+        return Colors.purple;
+      case 'VIP':
+        return Colors.yellow;
+      default:
+        return Colors.grey.shade200;
+    }
+  }
+
+  Color tagTextColor(String tag) {
+    switch (tag) {
+      case 'Новый':
+      case 'VIP':
+        return Colors.black;
+      case 'Напомнить':
+        return Colors.white;
+      default:
+        return Colors.black;
+    }
+  }
+
+  static const Map<String, String> _brandSlug = {
+    'Telegram': 'telegram',
+    'VK': 'vk',
+    'Instagram': 'instagram',
+    'WhatsApp': 'whatsapp',
+    'TikTok': 'tiktok',
+    'Одноклассники': 'odnoklassniki',
+    'Facebook': 'facebook',
+    'Twitter': 'twitterx',
+    'X': 'twitterx',
+  };
+
+  String brandAssetPath(String value) {
+    final slug = _brandSlug[value];
+    if (slug == null) return '';
+    return 'assets/$slug.svg';
+  }
+
+  Widget brandIcon(String value, {double size = 24}) {
+    final path = brandAssetPath(value);
+    if (path.isEmpty) return const Icon(Icons.public);
+    return SvgPicture.asset(
+      path,
+      width: size,
+      height: size,
+      semanticsLabel: value,
+      placeholderBuilder: (_) => const Icon(Icons.public),
+    );
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    nameController.dispose();
+    birthController.dispose();
+    professionController.dispose();
+    cityController.dispose();
+    phoneController.dispose();
+    emailController.dispose();
+    socialController.dispose();
+    categoryController.dispose();
+    statusController.dispose();
+    commentController.dispose();
+    addedController.dispose();
+
+    focusBirth.dispose();
+    focusSocial.dispose();
+    focusCategory.dispose();
+    focusStatus.dispose();
+    focusAdded.dispose();
+    super.dispose();
+  }
+}

--- a/lib/screens/add_contact/add_contact_preview.dart
+++ b/lib/screens/add_contact/add_contact_preview.dart
@@ -1,0 +1,183 @@
+part of add_contact_screen;
+
+class AddContactPreview extends StatelessWidget {
+  final AddContactFormController controller;
+  const AddContactPreview({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _PreviewCaption(controller: controller),
+        const SizedBox(height: 8),
+        _PreviewCard(controller: controller),
+      ],
+    );
+  }
+}
+
+class _PreviewCaption extends StatelessWidget {
+  final AddContactFormController controller;
+  const _PreviewCaption({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final text = 'Предпросмотр карточки';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
+      child: Row(
+        children: [
+          Icon(Icons.visibility_outlined, size: 16, color: theme.hintColor),
+          const SizedBox(width: 6),
+          Text(
+            text,
+            style: theme.textTheme.labelMedium?.copyWith(color: theme.hintColor),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PreviewCard extends StatelessWidget {
+  final AddContactFormController controller;
+  const _PreviewCard({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    const double statusReserve = 120;
+    final scheme = Theme.of(context).colorScheme;
+    final name = controller.nameController.text.trim().isEmpty
+        ? 'Новый контакт'
+        : controller.nameController.text.trim();
+    final statusValue = (controller.status ?? controller.statusController.text).trim();
+    final statusText = statusValue.isEmpty ? 'Статус' : statusValue;
+    final statusBg =
+        statusValue.isEmpty ? Colors.grey : controller.statusColor(statusValue);
+    final onStatus = controller.onStatus(statusBg);
+    final tags = controller.tags.toList();
+
+    Widget avatar() {
+      final bg = controller.avatarBgFor(name, scheme);
+      final initials = controller.initials(name);
+      return Container(
+        width: 44,
+        height: 44,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          border: Border.all(color: scheme.surface, width: 0),
+        ),
+        child: CircleAvatar(
+          backgroundColor: bg,
+          child: Text(
+            initials.isEmpty ? '?' : initials,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+        ),
+      );
+    }
+
+    return Semantics(
+      label:
+          'Превью контакта. Имя: $name. Статус: $statusText. Телефон: ${controller.previewPhoneMasked()}.',
+      child: Card(
+        elevation: 2,
+        margin: EdgeInsets.zero,
+        color: scheme.surfaceVariant,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Stack(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(right: statusReserve),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        avatar(),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            name,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleLarge
+                                ?.copyWith(fontWeight: FontWeight.w600),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      controller.previewPhoneMasked(),
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    if (tags.isNotEmpty)
+                      Wrap(
+                        spacing: 4,
+                        runSpacing: 4,
+                        children: [
+                          for (final tag in tags)
+                            Chip(
+                              label: Text(
+                                tag,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodySmall
+                                    ?.copyWith(
+                                      fontSize: 10,
+                                      color: controller.tagTextColor(tag),
+                                    ),
+                              ),
+                              backgroundColor: controller.tagColor(tag),
+                              visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+                              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 0),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(30),
+                              ),
+                            ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+              Positioned(
+                top: 0,
+                right: 0,
+                child: Chip(
+                  label: Text(
+                    statusText,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(fontSize: 10, color: onStatus),
+                  ),
+                  backgroundColor: statusBg,
+                  visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 0),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                    side: BorderSide(color: onStatus.withOpacity(0.25), width: 1),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -1,3 +1,5 @@
+library add_contact_screen;
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
@@ -7,6 +9,9 @@ import 'package:characters/characters.dart';
 import '../models/contact.dart';
 import '../services/contact_database.dart';
 import '../widgets/system_notifications.dart';
+
+part 'add_contact/add_contact_controller.dart';
+part 'add_contact/add_contact_preview.dart';
 
 /// Словари (централизовано, без «магических» строк)
 abstract class Dict {
@@ -30,35 +35,78 @@ class AddContactScreen extends StatefulWidget {
 }
 
 class _AddContactScreenState extends State<AddContactScreen> {
-  final _formKey = GlobalKey<FormState>();
-  final _scroll = ScrollController();
+  late final AddContactFormController _form;
 
-  // Keys для автоскролла к ошибкам
-  final _nameKey = GlobalKey();
-  final _phoneKey = GlobalKey();
-  final _categoryKey = GlobalKey();
-  final _statusKey = GlobalKey();
-  final _addedKey = GlobalKey();
+  GlobalKey<FormState> get _formKey => _form.formKey;
+  ScrollController get _scroll => _form.scrollController;
 
-  // Controllers
-  final _nameController = TextEditingController();
-  final _birthController = TextEditingController();
-  final _professionController = TextEditingController();
-  final _cityController = TextEditingController();
-  final _phoneController = TextEditingController();
-  final _emailController = TextEditingController();
-  final _socialController = TextEditingController(); // единый источник правды
-  final _categoryController = TextEditingController();
-  final _statusController = TextEditingController();
-  final _commentController = TextEditingController();
-  final _addedController = TextEditingController();
+  GlobalKey get _nameKey => _form.nameKey;
+  GlobalKey get _phoneKey => _form.phoneKey;
+  GlobalKey get _categoryKey => _form.categoryKey;
+  GlobalKey get _statusKey => _form.statusKey;
+  GlobalKey get _addedKey => _form.addedKey;
+  GlobalKey get _extraCardKey => _form.extraCardKey;
 
-  // --- UI state ---
-  bool _submitted = false;
-  bool _saving = false;
+  TextEditingController get _nameController => _form.nameController;
+  TextEditingController get _birthController => _form.birthController;
+  TextEditingController get _professionController => _form.professionController;
+  TextEditingController get _cityController => _form.cityController;
+  TextEditingController get _phoneController => _form.phoneController;
+  TextEditingController get _emailController => _form.emailController;
+  TextEditingController get _socialController => _form.socialController;
+  TextEditingController get _categoryController => _form.categoryController;
+  TextEditingController get _statusController => _form.statusController;
+  TextEditingController get _commentController => _form.commentController;
+  TextEditingController get _addedController => _form.addedController;
 
-  // --- key для «Дополнительно» ---
-  final _extraCardKey = GlobalKey();
+  bool get _submitted => _form.submitted;
+  set _submitted(bool value) => _form.setSubmitted(value);
+
+  bool get _saving => _form.saving;
+  set _saving(bool value) => _form.setSaving(value);
+
+  DateTime? get _birthDate => _form.birthDate;
+  set _birthDate(DateTime? value) => _form.setBirthDate(value);
+
+  int? get _ageManual => _form.ageManual;
+  set _ageManual(int? value) => _form.setAgeManual(value);
+
+  String? get _category => _form.category;
+  set _category(String? value) => _form.setCategory(value);
+
+  String? get _status => _form.status;
+  set _status(String? value) => _form.setStatus(value);
+
+  DateTime get _addedDate => _form.addedDate;
+  set _addedDate(DateTime value) => _form.updateAddedDate(value);
+
+  Set<String> get _tags => _form.tags;
+
+  bool get _birthOpen => _form.birthOpen;
+  set _birthOpen(bool value) => _form.setBirthOpen(value);
+
+  bool get _socialOpen => _form.socialOpen;
+  set _socialOpen(bool value) => _form.setSocialOpen(value);
+
+  bool get _categoryOpen => _form.categoryOpen;
+  set _categoryOpen(bool value) => _form.setCategoryOpen(value);
+
+  bool get _statusOpen => _form.statusOpen;
+  set _statusOpen(bool value) => _form.setStatusOpen(value);
+
+  bool get _addedOpen => _form.addedOpen;
+  set _addedOpen(bool value) => _form.setAddedOpen(value);
+
+  bool get _extraExpanded => _form.extraExpanded;
+  set _extraExpanded(bool value) => _form.setExtraExpanded(value);
+
+  FocusNode get _focusBirth => _form.focusBirth;
+  FocusNode get _focusSocial => _form.focusSocial;
+  FocusNode get _focusCategory => _form.focusCategory;
+  FocusNode get _focusStatus => _form.focusStatus;
+  FocusNode get _focusAdded => _form.focusAdded;
+
+  MaskTextInputFormatter get _phoneMask => _form.phoneMask;
 
   Future<void> _scrollToCard(GlobalKey key) async {
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -79,406 +127,32 @@ class _AddContactScreenState extends State<AddContactScreen> {
     FocusScope.of(context).requestFocus(_focusCategory);
   }
 
-  // ==== PREVIEW HELPERS ====
-  Color _avatarBgFor(String seed, ColorScheme scheme) {
-    int h = 0;
-    for (final r in seed.runes) {
-      h = (h * 31 + r) & 0x7fffffff;
-    }
-    final hue = (h % 360).toDouble();
-    final hsl = HSLColor.fromAHSL(1.0, hue, 0.45, 0.55);
-    return hsl.toColor();
-  }
-
-  IconData _statusIcon(String s) {
-    switch (s) {
-      case 'Активный':
-        return Icons.check_circle;
-      case 'Пассивный':
-        return Icons.pause_circle;
-      case 'Потерянный':
-        return Icons.cancel;
-      case 'Холодный':
-        return Icons.ac_unit;
-      case 'Тёплый':
-        return Icons.local_fire_department;
-      default:
-        return Icons.label_outline;
-    }
-  }
-
-  IconData _categoryIcon(String? c) {
-    switch (c) {
-      case 'Партнёр':
-        return Icons.handshake;
-      case 'Клиент':
-        return Icons.people;
-      case 'Потенциальный':
-        return Icons.person_add_alt_1;
-      default:
-        return Icons.person_outline;
-    }
-  }
-
-  Color _statusColor(String status) {
-    switch (status) {
-      case 'Активный':
-        return Colors.green;
-      case 'Пассивный':
-        return Colors.orange;
-      case 'Потерянный':
-        return Colors.red;
-      case 'Холодный':
-        return Colors.cyan;
-      case 'Тёплый':
-        return Colors.pink;
-      default:
-        return Colors.grey;
-    }
-  }
-
-  // читабельный цвет текста на ярких чипах статуса
-  Color _onStatus(Color bg) {
-    final brightness = bg.computeLuminance();
-    return brightness > 0.5 ? Colors.black : Colors.white;
-  }
-
-  Color _tagColor(String tag) {
-    switch (tag) {
-      case 'Новый':
-        return Colors.white;
-      case 'Напомнить':
-        return Colors.purple;
-      case 'VIP':
-        return Colors.yellow;
-      default:
-        return Colors.grey.shade200;
-    }
-  }
-
-  Color _tagTextColor(String tag) {
-    switch (tag) {
-      case 'Новый':
-      case 'VIP':
-        return Colors.black;
-      case 'Напомнить':
-        return Colors.white;
-      default:
-        return Colors.black;
-    }
-  }
-
-  // Прогрессивная маска телефона для превью
-  String _previewPhoneMasked() {
-    final digits = _phoneMask.getUnmaskedText(); // 0..10
-    const mask = '+7 (XXX) XXX-XX-XX';
-    final buf = StringBuffer();
-    int di = 0;
-    for (int i = 0; i < mask.length; i++) {
-      final ch = mask[i];
-      if (ch == 'X') {
-        if (di < digits.length) {
-          buf.write(digits[di]);
-          di++;
-        } else {
-          buf.write('X');
-        }
-      } else {
-        buf.write(ch);
-      }
-    }
-    return buf.toString();
-  }
-
-  Widget _previewCaption(BuildContext context, {String text = 'Предпросмотр карточки'}) {
-    final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(4, 0, 4, 8),
-      child: Row(
-        children: [
-          Icon(Icons.visibility_outlined, size: 16, color: theme.hintColor),
-          const SizedBox(width: 6),
-          Text(
-            text,
-            style: theme.textTheme.labelMedium?.copyWith(color: theme.hintColor),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildHeaderPreview(BuildContext context) {
-    const double kStatusReserve = 120;
-    final scheme = Theme.of(context).colorScheme;
-    final name = _nameController.text.trim().isEmpty ? 'Новый контакт' : _nameController.text.trim();
-    final statusValue = (_status ?? _statusController.text).trim();
-    final statusText = statusValue.isEmpty ? 'Статус' : statusValue;
-    final statusBg = statusValue.isEmpty ? Colors.grey : _statusColor(statusValue);
-    final onStatus = _onStatus(statusBg);
-    final tags = _tags.toList();
-
-    Widget avatar() {
-      final bg = _avatarBgFor(name, scheme);
-      final initials = _initials(name);
-      return Container(
-        width: 44,
-        height: 44,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          border: Border.all(color: scheme.surface, width: 0),
-        ),
-        child: CircleAvatar(
-          backgroundColor: bg,
-          child: Text(
-            initials.isEmpty ? '?' : initials,
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: Colors.white,
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-        ),
-      );
-    }
-
-    return Semantics(
-      label: 'Превью контакта. Имя: $name. Статус: $statusText. Телефон: ${_previewPhoneMasked()}.',
-      child: Card(
-        elevation: 2,
-        margin: EdgeInsets.zero,
-        color: scheme.surfaceVariant,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Stack(
-            children: [
-              Padding(
-                padding: const EdgeInsets.only(right: kStatusReserve),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        avatar(),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Text(
-                            name,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      _previewPhoneMasked(),
-                      style: Theme.of(context).textTheme.bodyMedium,
-                    ),
-                    const SizedBox(height: 8),
-                    if (tags.isNotEmpty)
-                      Wrap(
-                        spacing: 4,
-                        runSpacing: 4,
-                        children: [
-                          for (final tag in tags)
-                            Chip(
-                              label: Text(
-                                tag,
-                                style: Theme.of(context).textTheme.bodySmall?.copyWith(fontSize: 10, color: _tagTextColor(tag)),
-                              ),
-                              backgroundColor: _tagColor(tag),
-                              visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-                              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 0),
-                              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
-                            ),
-                        ],
-                      ),
-                  ],
-                ),
-              ),
-              Positioned(
-                top: 0,
-                right: 0,
-                child: Chip(
-                  label: Text(
-                    statusText,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(fontSize: 10, color: onStatus),
-                  ),
-                  backgroundColor: statusBg,
-                  visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 0),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
-                    side: BorderSide(color: onStatus.withOpacity(0.25), width: 1),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  // ====== Состояния ======
-  DateTime? _birthDate;
-  int? _ageManual;
-  String? _category;
-  String? _status;
-  DateTime _addedDate = DateTime.now();
-  final Set<String> _tags = {};
-  bool _birthOpen = false;
-  bool _socialOpen = false;
-  bool _categoryOpen = false;
-  bool _statusOpen = false;
-  bool _addedOpen = false;
-  bool _extraExpanded = false; // «Дополнительно» изначально свёрнут
-
-  // FocusNodes — чтобы переводить фокус на «тайловые» поля
-  final FocusNode _focusBirth = FocusNode(skipTraversal: true);
-  final FocusNode _focusSocial = FocusNode(skipTraversal: true);
-  final FocusNode _focusCategory = FocusNode(skipTraversal: true);
-  final FocusNode _focusStatus = FocusNode(skipTraversal: true);
-  final FocusNode _focusAdded = FocusNode(skipTraversal: true);
-
-  final _phoneMask = MaskTextInputFormatter(
-    mask: '+7 (###) ###-##-##',
-    filter: {'#': RegExp(r'[0-9]')},
-  );
-
-  // ===== Брендовые иконки (из папки assets/) =====
-  static const Map<String, String> _brandSlug = {
-    'Telegram': 'telegram',
-    'VK': 'vk',
-    'Instagram': 'instagram',
-    'WhatsApp': 'whatsapp',
-    'TikTok': 'tiktok',
-    'Одноклассники': 'odnoklassniki',
-    'Facebook': 'facebook',
-    'Twitter': 'twitterx',
-    'X': 'twitterx',
-  };
-
-  String _brandAssetPath(String value) {
-    final slug = _brandSlug[value];
-    if (slug == null) return '';
-    return 'assets/$slug.svg';
-  }
-
-  Widget _brandIcon(String value, {double size = 24}) {
-    final path = _brandAssetPath(value);
-    if (path.isEmpty) return const Icon(Icons.public);
-    return SvgPicture.asset(
-      path,
-      width: size,
-      height: size,
-      semanticsLabel: value,
-      placeholderBuilder: (_) => const Icon(Icons.public),
-    );
+  void _onFormChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
   void initState() {
     super.initState();
-    if (widget.category != null) {
-      _category = widget.category;
-      _categoryController.text = widget.category!;
-    }
-    _addedController.text = DateFormat('dd.MM.yyyy').format(_addedDate);
-
-    // Обновление превью по ключевым полям
-    _nameController.addListener(() => setState(() {}));
-    _phoneController.addListener(() => setState(() {}));
-    _emailController.addListener(() => setState(() {}));
-    _professionController.addListener(() => setState(() {}));
-    _cityController.addListener(() => setState(() {}));
-    _commentController.addListener(() => setState(() {}));
-
-    _focusCategory.addListener(() => setState(() {}));
-    _focusStatus.addListener(() => setState(() {}));
-    _focusSocial.addListener(() => setState(() {}));
-    _focusBirth.addListener(() => setState(() {}));
-    _focusAdded.addListener(() => setState(() {}));
+    _form = AddContactFormController(initialCategory: widget.category)
+      ..addListener(_onFormChanged);
   }
 
   @override
   void dispose() {
-    _scroll.dispose();
-    _nameController.dispose();
-    _birthController.dispose();
-    _professionController.dispose();
-    _cityController.dispose();
-    _phoneController.dispose();
-    _emailController.dispose();
-    _socialController.dispose();
-    _categoryController.dispose();
-    _statusController.dispose();
-    _commentController.dispose();
-    _addedController.dispose();
-
-    _focusBirth.dispose();
-    _focusSocial.dispose();
-    _focusCategory.dispose();
-    _focusStatus.dispose();
-    _focusAdded.dispose();
+    _form.removeListener(_onFormChanged);
+    _form.dispose();
     super.dispose();
   }
 
   // ==================== helpers ====================
   void _defocus() => FocusScope.of(context).unfocus();
 
-  int _calcAge(DateTime birth) {
-    final now = DateTime.now();
-    var age = now.year - birth.year;
-    if (now.month < birth.month || (now.month == birth.month && now.day < birth.day)) {
-      age--;
-    }
-    return age;
-  }
+  Future<void> _ensureVisible(GlobalKey key) => _form.scrollToCard(key);
 
-  String _formatAge(int age) {
-    final lastTwo = age % 100;
-    final last = age % 10;
-    if (lastTwo >= 11 && lastTwo <= 14) return '$age лет';
-    if (last == 1) return '$age год';
-    if (last >= 2 && last <= 4) return '$age года';
-    return '$age лет';
-  }
+  bool get _phoneValid => _form.phoneValid;
 
-  String _initials(String name) {
-    final parts = name.trim().split(RegExp(r'\s+')).where((e) => e.isNotEmpty).toList();
-    if (parts.isEmpty) return '';
-    if (parts.length == 1) {
-      return parts.first.characters.take(2).toString().toUpperCase();
-    }
-    return (parts.first.characters.take(1).toString() + parts[1].characters.take(1).toString()).toUpperCase();
-  }
-
-  Future<void> _ensureVisible(GlobalKey key) async {
-    final ctx = key.currentContext;
-    if (ctx != null) {
-      await Scrollable.ensureVisible(
-        ctx,
-        duration: const Duration(milliseconds: 350),
-        curve: Curves.easeOut,
-        alignment: 0.1,
-      );
-    }
-  }
-
-  bool get _phoneValid => _phoneMask.getUnmaskedText().length == 10;
-
-  bool get _canSave =>
-      _nameController.text.trim().isNotEmpty &&
-          _phoneValid &&
-          _category != null &&
-          _status != null &&
-          _addedController.text.trim().isNotEmpty &&
-          !_saving;
+  bool get _canSave => _form.canSave;
 
   // ==================== pickers ====================
   Future<void> _pickBirthOrAge() async {
@@ -524,11 +198,10 @@ class _AddContactScreenState extends State<AddContactScreen> {
         confirmText: 'Выбрать',
       );
       if (picked != null) {
-        _birthDate = picked;
-        _ageManual = null;
-        final age = _calcAge(picked);
-        _birthController.text = '${DateFormat('dd.MM.yyyy').format(picked)} (${_formatAge(age)})';
-        setState(() {});
+        setState(() {
+          _birthDate = picked;
+          _ageManual = null;
+        });
       }
     } else if (choice == 'age') {
       final ctrl = TextEditingController();
@@ -554,10 +227,10 @@ class _AddContactScreenState extends State<AddContactScreen> {
         ),
       );
       if (age != null) {
-        _ageManual = age;
-        _birthDate = null;
-        _birthController.text = 'Возраст: ${_formatAge(age)}';
-        setState(() {});
+        setState(() {
+          _ageManual = age;
+          _birthDate = null;
+        });
       }
     }
   }
@@ -581,14 +254,14 @@ class _AddContactScreenState extends State<AddContactScreen> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  ListTile(leading: _brandIcon('Telegram'), title: const Text('Telegram'), onTap: () => Navigator.pop(context, 'Telegram')),
-                  ListTile(leading: _brandIcon('VK'), title: const Text('VK'), onTap: () => Navigator.pop(context, 'VK')),
-                  ListTile(leading: _brandIcon('Instagram'), title: const Text('Instagram'), onTap: () => Navigator.pop(context, 'Instagram')),
-                  ListTile(leading: _brandIcon('Facebook'), title: const Text('Facebook'), onTap: () => Navigator.pop(context, 'Facebook')),
-                  ListTile(leading: _brandIcon('WhatsApp'), title: const Text('WhatsApp'), onTap: () => Navigator.pop(context, 'WhatsApp')),
-                  ListTile(leading: _brandIcon('TikTok'), title: const Text('TikTok'), onTap: () => Navigator.pop(context, 'TikTok')),
-                  ListTile(leading: _brandIcon('Одноклассники'), title: const Text('Одноклассники'), onTap: () => Navigator.pop(context, 'Одноклассники')),
-                  ListTile(leading: _brandIcon('Twitter'), title: const Text('Twitter'), onTap: () => Navigator.pop(context, 'Twitter')),
+                  ListTile(leading: _form.brandIcon('Telegram'), title: const Text('Telegram'), onTap: () => Navigator.pop(context, 'Telegram')),
+                  ListTile(leading: _form.brandIcon('VK'), title: const Text('VK'), onTap: () => Navigator.pop(context, 'VK')),
+                  ListTile(leading: _form.brandIcon('Instagram'), title: const Text('Instagram'), onTap: () => Navigator.pop(context, 'Instagram')),
+                  ListTile(leading: _form.brandIcon('Facebook'), title: const Text('Facebook'), onTap: () => Navigator.pop(context, 'Facebook')),
+                  ListTile(leading: _form.brandIcon('WhatsApp'), title: const Text('WhatsApp'), onTap: () => Navigator.pop(context, 'WhatsApp')),
+                  ListTile(leading: _form.brandIcon('TikTok'), title: const Text('TikTok'), onTap: () => Navigator.pop(context, 'TikTok')),
+                  ListTile(leading: _form.brandIcon('Одноклассники'), title: const Text('Одноклассники'), onTap: () => Navigator.pop(context, 'Одноклассники')),
+                  ListTile(leading: _form.brandIcon('Twitter'), title: const Text('Twitter'), onTap: () => Navigator.pop(context, 'Twitter')),
                 ],
               ),
             ),
@@ -629,8 +302,6 @@ class _AddContactScreenState extends State<AddContactScreen> {
       setState(() {
         _category = result;
         _status = null;
-        _categoryController.text = result;
-        _statusController.text = '';
       });
     }
   }
@@ -650,7 +321,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
           children: [
             for (final s in options)
               ListTile(
-                leading: Icon(_statusIcon(s)),
+                leading: Icon(_form.statusIcon(s)),
                 title: Text(s),
                 onTap: () => Navigator.pop(context, s),
               ),
@@ -663,7 +334,6 @@ class _AddContactScreenState extends State<AddContactScreen> {
     if (result != null) {
       setState(() {
         _status = result;
-        _statusController.text = result;
       });
     }
   }
@@ -686,10 +356,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
 
     setState(() => _addedOpen = false);
     if (picked != null) {
-      setState(() {
-        _addedDate = picked;
-        _addedController.text = DateFormat('dd.MM.yyyy').format(picked);
-      });
+      setState(() => _addedDate = picked);
     }
   }
 
@@ -922,7 +589,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       ).copyWith(
         prefixIcon: Padding(
           padding: const EdgeInsets.all(10),
-          child: value.isEmpty ? const Icon(Icons.public, size: 20) : _brandIcon(value, size: 20),
+          child: value.isEmpty ? const Icon(Icons.public, size: 20) : _form.brandIcon(value, size: 20),
         ),
       ),
       onTap: () {
@@ -971,15 +638,9 @@ class _AddContactScreenState extends State<AddContactScreen> {
               padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
               children: [
                 // ===== Превью =====
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _previewCaption(context),
-                    KeyedSubtree(
-                      key: const ValueKey('header_preview'),
-                      child: _buildHeaderPreview(context),
-                    ),
-                  ],
+                KeyedSubtree(
+                  key: const ValueKey('header_preview'),
+                  child: AddContactPreview(controller: _form),
                 ),
                 const SizedBox(height: 24),
 
@@ -1038,7 +699,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                   children: [
                     _pickerField(
                       key: _categoryKey,
-                      icon: _categoryIcon(catValue),
+                      icon: _form.categoryIcon(catValue),
                       title: 'Категория*',
                       controller: _categoryController,
                       hint: 'Выберите категорию',
@@ -1047,12 +708,12 @@ class _AddContactScreenState extends State<AddContactScreen> {
                       onTap: _pickCategory,
                       requiredField: true,
                       forceFloatingLabel: categoryEmpty,
-                      prefix: Icon(_categoryIcon(catValue)),
+                      prefix: Icon(_form.categoryIcon(catValue)),
                     ),
                     const SizedBox(height: 12),
                     _pickerField(
                       key: _statusKey,
-                      icon: _statusIcon(statusValue.isEmpty ? 'Статус' : statusValue),
+                      icon: _form.statusIcon(statusValue.isEmpty ? 'Статус' : statusValue),
                       title: 'Статус*',
                       controller: _statusController,
                       hint: _category == null ? 'Сначала выберите категорию' : 'Выберите статус',
@@ -1068,8 +729,10 @@ class _AddContactScreenState extends State<AddContactScreen> {
                       requiredField: true,
                       forceFloatingLabel: statusEmpty,
                       prefix: Icon(
-                        _statusIcon(statusValue.isEmpty ? 'Статус' : statusValue),
-                        color: statusValue.isEmpty ? Theme.of(context).hintColor : _statusColor(statusValue),
+                        _form.statusIcon(statusValue.isEmpty ? 'Статус' : statusValue),
+                        color: statusValue.isEmpty
+                            ? Theme.of(context).hintColor
+                            : _form.statusColor(statusValue),
                       ),
                     ),
                   ],
@@ -1088,13 +751,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                             label: Text(label),
                             selected: _tags.contains(label),
                             onSelected: (v) {
-                              setState(() {
-                                if (v) {
-                                  _tags.add(label);
-                                } else {
-                                  _tags.remove(label);
-                                }
-                              });
+                              setState(() => _form.toggleTag(label));
                             },
                           ),
                       ],

--- a/lib/screens/home/home_actions.dart
+++ b/lib/screens/home/home_actions.dart
@@ -1,0 +1,61 @@
+part of home_screen;
+
+class HomeActions {
+  const HomeActions();
+
+  Future<void> openSupport(BuildContext context) async {
+    const group = 'touchnotebook';
+    final tgUri = Uri.parse('tg://resolve?domain=$group');
+    final webUri = Uri.parse('https://t.me/$group');
+    try {
+      if (kIsWeb) {
+        await launchUrl(webUri, mode: LaunchMode.platformDefault);
+        return;
+      }
+      if (await canLaunchUrl(tgUri)) {
+        await launchUrl(tgUri, mode: LaunchMode.externalApplication);
+      } else {
+        showWarningBanner(R.telegramNotInstalled);
+        await launchUrl(webUri, mode: LaunchMode.externalApplication);
+      }
+    } catch (e, s) {
+      debugPrint('openSupport error: $e\n$s');
+      showErrorBanner(R.telegramOpenFailed);
+      await Clipboard.setData(
+        const ClipboardData(text: 'https://t.me/touchnotebook'),
+      );
+      showInfoBanner(R.linkCopied);
+    }
+  }
+
+  Future<void> openAddContact(BuildContext context) async {
+    if (!kIsWeb) HapticFeedback.selectionClick();
+    final saved = await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const AddContactScreen()),
+    );
+    if (saved == true) {
+      showSuccessBanner(R.contactSaved);
+    }
+  }
+
+  void openSettings(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const SettingsScreen()),
+    );
+  }
+
+  void openCategoryList(BuildContext context, ContactCategory category) {
+    if (!kIsWeb) HapticFeedback.selectionClick();
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ContactListScreen(
+          category: category.dbKey,
+          title: category.titlePlural,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home/home_controller.dart
+++ b/lib/screens/home/home_controller.dart
@@ -1,0 +1,75 @@
+part of home_screen;
+
+class HomeStateController {
+  HomeStateController({
+    ContactDatabase? database,
+    Duration refreshDebounce = const Duration(milliseconds: 200),
+  })  : _database = database ?? ContactDatabase.instance,
+        _refreshDebounce = refreshDebounce;
+
+  final ContactDatabase _database;
+  final Duration _refreshDebounce;
+
+  Timer? _debounce;
+  Counts? _lastCountsShown;
+  Counts? _lastGoodCounts;
+
+  Counts? get lastGoodCounts => _lastGoodCounts;
+
+  Future<int> _safe(Future<int> future) async {
+    try {
+      return await future.timeout(const Duration(seconds: 3));
+    } catch (e, s) {
+      debugPrint('count error: $e\n$s');
+      return -1; // -1 = неизвестно
+    }
+  }
+
+  Future<Counts> loadCounts() async {
+    final partner = await _safe(
+      _database.countByCategory(ContactCategory.partner.dbKey),
+    );
+    final client = await _safe(
+      _database.countByCategory(ContactCategory.client.dbKey),
+    );
+    final prospect = await _safe(
+      _database.countByCategory(ContactCategory.prospect.dbKey),
+    );
+    return Counts({
+      ContactCategory.partner: partner,
+      ContactCategory.client: client,
+      ContactCategory.prospect: prospect,
+    });
+  }
+
+  VoidCallback listenForRevisionUpdates(VoidCallback triggerRefresh) {
+    void listener() => scheduleRefresh(triggerRefresh);
+    _database.revision.addListener(listener);
+    return () => _database.revision.removeListener(listener);
+  }
+
+  void scheduleRefresh(VoidCallback triggerRefresh) {
+    _debounce?.cancel();
+    _debounce = Timer(_refreshDebounce, triggerRefresh);
+  }
+
+  Counts effectiveCounts(AsyncSnapshot<Counts> snapshot) {
+    return snapshot.data ?? _lastGoodCounts ?? const Counts.zero();
+  }
+
+  bool registerCounts(Counts newCounts) {
+    final last = _lastCountsShown;
+    _lastCountsShown = newCounts;
+    if (newCounts.unknownCount == 0 || newCounts.knownTotal > 0) {
+      _lastGoodCounts = newCounts;
+    }
+    if (last == null) {
+      return false;
+    }
+    return last.unknownCount > 0 && newCounts.unknownCount < last.unknownCount;
+  }
+
+  void dispose() {
+    _debounce?.cancel();
+  }
+}

--- a/lib/screens/home/home_definitions.dart
+++ b/lib/screens/home/home_definitions.dart
@@ -1,0 +1,191 @@
+part of home_screen;
+
+/// ---------------------
+/// Строки (русская локаль)
+/// ---------------------
+abstract class R {
+  static const appTitle = 'Touch NoteBook';
+  static const homeTitle = 'Главный экран';
+  static const settings = 'Настройки';
+  static const support = 'Поддержка';
+  static const addContact = 'Добавить контакт';
+  static const contactSaved = 'Контакт сохранён';
+  static const noContacts = 'Пока нет контактов';
+  static const noData = 'Нет данных';
+  static const loadError = 'Не удалось загрузить данные';
+  static const tryAgain = 'Повторить';
+  static const checkNetwork = 'Проверьте подключение к сети и попробуйте ещё раз.';
+  static const telegramNotInstalled = 'Telegram не установлен, откроем в браузере';
+  static const telegramOpenFailed = 'Не удалось открыть Telegram';
+  static const loading = 'Загрузка…';
+  static const unknown = 'Неизвестно';
+  static const qtyLabel = 'Количество';
+  static const summaryTitle = 'Сводка по контактам';
+  static const summaryKnownLabel = 'Всего известных контактов';
+  static const summaryAllKnown = 'Все категории синхронизированы';
+  static const quickActions = 'Быстрые действия';
+  static const linkCopied = 'Ссылка скопирована';
+  static const emptyStateHelp =
+      'Создайте первый контакт. Ниже можно открыть списки по категориям.';
+  static const chipHintOpenList = 'Откройте список по категории';
+  static const dataUpdated = 'Данные обновлены';
+
+  static String summaryUnknown(int count) {
+    if (count <= 0) return summaryAllKnown;
+    final noun = (count == 1) ? 'категории' : 'категориям';
+    return 'По $count\u00A0$noun пока нет данных';
+  }
+}
+
+/// ---------------------
+/// Константы оформления
+/// ---------------------
+const kPad16 = EdgeInsets.all(16);
+const kGap6 = SizedBox(height: 6);
+const kGap8 = SizedBox(height: 8);
+const kGap12 = SizedBox(height: 12);
+const kGap16w = SizedBox(width: 16);
+const kDurTap = Duration(milliseconds: 120);
+const kDurFast = Duration(milliseconds: 200);
+const kBr16 = BorderRadius.all(Radius.circular(16));
+
+EdgeInsets homeListPadding(BuildContext context) {
+  // SafeArea уже обрабатывает системные отступы снизу.
+  const fabEstimatedHeight = 56.0; // высота FAB.extended
+  const bottom = 16 + kFloatingActionButtonMargin + fabEstimatedHeight;
+  return const EdgeInsets.fromLTRB(16, 16, 16, bottom);
+}
+
+/// Кешированный форматтер чисел для RU
+final NumberFormat homeNumberFormat = NumberFormat.decimalPattern('ru');
+
+/// ---------------------
+/// Типобезопасные категории
+/// ---------------------
+enum ContactCategory { partner, client, prospect }
+
+extension ContactCategoryX on ContactCategory {
+  String get dbKey => switch (this) {
+        ContactCategory.partner => 'Партнёр',
+        ContactCategory.client => 'Клиент',
+        ContactCategory.prospect => 'Потенциальный',
+      };
+
+  String get titlePlural => switch (this) {
+        ContactCategory.partner => 'Партнёры',
+        ContactCategory.client => 'Клиенты',
+        ContactCategory.prospect => 'Потенциальные клиенты',
+      };
+
+  IconData get icon => switch (this) {
+        ContactCategory.partner => Icons.handshake,
+        ContactCategory.client => Icons.people,
+        ContactCategory.prospect => Icons.person_add_alt_1,
+      };
+
+  /// Склонение + неразрывный пробел
+  String russianCount(int count) {
+    if (count == 0) {
+      return switch (this) {
+        ContactCategory.partner => 'Нет партнёров',
+        ContactCategory.client => 'Нет клиентов',
+        ContactCategory.prospect => 'Нет потенциальных клиентов',
+      };
+    }
+    final m10 = count % 10;
+    final m100 = count % 100;
+
+    String pick({required String one, required String few, required String many}) {
+      final word = (m10 == 1 && m100 != 11)
+          ? one
+          : (m10 >= 2 && m10 <= 4 && (m100 < 10 || m100 >= 20))
+              ? few
+              : many;
+      return '${homeNumberFormat.format(count)}\u00A0$word';
+    }
+
+    return switch (this) {
+      ContactCategory.partner =>
+          pick(one: 'партнёр', few: 'партнёра', many: 'партнёров'),
+      ContactCategory.client =>
+          pick(one: 'клиент', few: 'клиента', many: 'клиентов'),
+      ContactCategory.prospect => pick(
+          one: 'потенциальный клиент',
+          few: 'потенциальных клиента',
+          many: 'потенциальных клиентов',
+        ),
+    };
+  }
+}
+
+/// ---------------------
+/// Типобезопасные счётчики
+/// ---------------------
+class Counts {
+  final Map<ContactCategory, int> _values;
+
+  const Counts(this._values);
+
+  const Counts.zero()
+      : _values = const {
+          ContactCategory.partner: 0,
+          ContactCategory.client: 0,
+          ContactCategory.prospect: 0,
+        };
+
+  int of(ContactCategory c) => _values[c] ?? 0;
+
+  bool get allZero => ContactCategory.values.every((c) => of(c) == 0);
+
+  int get knownTotal {
+    return ContactCategory.values.fold<int>(0, (sum, c) {
+      final value = of(c);
+      return value >= 0 ? sum + value : sum;
+    });
+  }
+
+  int get unknownCount =>
+      ContactCategory.values.where((c) => of(c) < 0).length;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! Counts) return false;
+    for (final c in ContactCategory.values) {
+      if (of(c) != other.of(c)) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAll(ContactCategory.values.map(of));
+}
+
+/// Определяем количество колонок для адаптива
+int calcColumns(BoxConstraints constraints) {
+  final width = constraints.maxWidth;
+  if (width >= 1200) return 3;
+  if (width >= 800) return 2;
+  return 1;
+}
+
+double gridChildAspectRatio(
+  BoxConstraints constraints,
+  int cols,
+  EdgeInsets listPadding,
+) {
+  final horizontalPadding = listPadding.left + listPadding.right;
+  const spacing = 12.0;
+  final totalSpacing = horizontalPadding + spacing * (cols - 1);
+  final availableWidth = constraints.maxWidth - totalSpacing;
+  final cellWidth = availableWidth <= 0 ? 1.0 : availableWidth / cols;
+  final viewportHeight = constraints.maxHeight;
+  final baseHeight = cellWidth / 1.9; // умеренно широкие карточки
+  const minHeight = 140.0;
+  final fallbackMaxHeight = cellWidth * 1.1;
+  final maxHeight = viewportHeight.isFinite
+      ? math.max(minHeight, viewportHeight * 0.6)
+      : fallbackMaxHeight;
+  final cellHeight = baseHeight.clamp(minHeight, maxHeight).toDouble();
+  return cellWidth / cellHeight;
+}

--- a/lib/screens/home/home_widgets.dart
+++ b/lib/screens/home/home_widgets.dart
@@ -1,0 +1,398 @@
+part of home_screen;
+
+class _EmptyStateCard extends StatelessWidget {
+  const _EmptyStateCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Card(
+      child: Padding(
+        padding: kPad16,
+        child: Column(
+          children: [
+            Icon(Icons.person_off, size: 40),
+            kGap8,
+            Text(R.noContacts),
+            kGap8,
+            Text(
+              R.emptyStateHelp,
+              textAlign: TextAlign.center,
+            ),
+            kGap8,
+            _AddContactButton(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AddContactButton extends StatelessWidget {
+  const _AddContactButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: () {
+        final state = context.findAncestorStateOfType<_HomeScreenState>();
+        state?._openAddContact();
+      },
+      icon: const Icon(Icons.person_add),
+      label: const Text(R.addContact),
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  final int knownTotal;
+  final int unknownCount;
+
+  const _SummaryCard({
+    required this.knownTotal,
+    required this.unknownCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final colorScheme = theme.colorScheme;
+    final hasUnknown = unknownCount > 0;
+
+    return Card(
+      child: Padding(
+        padding: kPad16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(R.summaryTitle, style: textTheme.titleMedium),
+            kGap8,
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        R.summaryKnownLabel,
+                        style: textTheme.labelMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        homeNumberFormat.format(knownTotal),
+                        style: textTheme.headlineMedium
+                            ?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ],
+                  ),
+                ),
+                if (hasUnknown)
+                  Semantics(
+                    label: 'Есть неизвестные категории',
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 12, top: 4),
+                      child: Icon(
+                        Icons.info_outline,
+                        color: colorScheme.secondary,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            kGap8,
+            Text(
+              hasUnknown
+                  ? R.summaryUnknown(unknownCount)
+                  : R.summaryAllKnown,
+              style: textTheme.bodyMedium
+                  ?.copyWith(color: colorScheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorCard extends StatefulWidget {
+  final Future<void> Function()? onRetry;
+  const _ErrorCard({super.key, required this.onRetry});
+
+  @override
+  State<_ErrorCard> createState() => _ErrorCardState();
+}
+
+class _ErrorCardState extends State<_ErrorCard> {
+  bool _busy = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final onRetry = widget.onRetry;
+    return Card(
+      child: Padding(
+        padding: kPad16,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(R.loadError, style: TextStyle(fontWeight: FontWeight.w600)),
+            kGap8,
+            const Text(R.checkNetwork),
+            kGap8,
+            FilledButton.icon(
+              onPressed: _busy || onRetry == null
+                  ? null
+                  : () async {
+                      setState(() => _busy = true);
+                      await onRetry();
+                      if (mounted) setState(() => _busy = false);
+                    },
+              icon: _busy
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.refresh),
+              label: Text(_busy ? R.loading : R.tryAgain),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryCard extends StatefulWidget {
+  final ContactCategory category;
+  final String subtitle;
+  final String? trailingCount;
+  final VoidCallback onTap;
+  final bool isLoading;
+
+  const _CategoryCard({
+    super.key,
+    required this.category,
+    required this.subtitle,
+    required this.onTap,
+    required this.trailingCount,
+    this.isLoading = false,
+  });
+
+  const _CategoryCard.loading({super.key, required ContactCategory category})
+      : category = category,
+        subtitle = R.loading,
+        trailingCount = null,
+        onTap = _noop,
+        isLoading = true;
+
+  static void _noop() {}
+
+  @override
+  State<_CategoryCard> createState() => _CategoryCardState();
+}
+
+class _CategoryCardState extends State<_CategoryCard> {
+  bool _pressed = false;
+
+  void _setPressed(bool value) {
+    if (widget.isLoading || _pressed == value) return;
+    setState(() => _pressed = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final isLoading = widget.isLoading;
+
+    Widget leadingIcon =
+        Icon(widget.category.icon, size: 32, color: colorScheme.primary);
+
+    if (!isLoading) {
+      leadingIcon = Hero(
+        tag: 'cat:${widget.category.dbKey}',
+        transitionOnUserGestures: true,
+        flightShuttleBuilder: (ctx, anim, dir, fromCtx, toCtx) {
+          return ScaleTransition(
+            scale: anim
+                .drive(Tween(begin: 0.9, end: 1.0).chain(CurveTween(curve: Curves.easeOut))),
+            child: Icon(widget.category.icon, size: 32, color: colorScheme.primary),
+          );
+        },
+        child: leadingIcon,
+      );
+    }
+
+    final String? countStr = widget.trailingCount;
+    final bool isUnknown = countStr == '—';
+
+    final Widget trailingContent = countStr == null
+        ? const Icon(Icons.chevron_right)
+        : Row(
+            key: ValueKey(countStr),
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Tooltip(
+                message: isUnknown
+                    ? 'Количество неизвестно — данные обновятся автоматически'
+                    : '${R.qtyLabel}: $countStr',
+                child: Semantics(
+                  label:
+                      '${widget.category.titlePlural}: ${R.qtyLabel.toLowerCase()}',
+                  value: isUnknown ? R.unknown : countStr,
+                  hint: '${R.chipHintOpenList}: ${widget.category.titlePlural}',
+                  child: Chip(
+                    label: Text(
+                      countStr,
+                      style: const TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                    backgroundColor: isUnknown
+                        ? colorScheme.surfaceVariant
+                        : colorScheme.primaryContainer,
+                    side: BorderSide(
+                      color: isUnknown
+                          ? colorScheme.outline
+                          : colorScheme.outlineVariant,
+                    ),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ),
+              ),
+              const Icon(Icons.chevron_right),
+            ],
+          );
+
+    return Semantics(
+      button: true,
+      label: widget.category.titlePlural,
+      value: widget.subtitle,
+      child: AnimatedScale(
+        scale: _pressed ? 0.985 : 1.0,
+        duration: kDurTap,
+        child: Material(
+          color: theme.colorScheme.surfaceContainerHigh,
+          elevation: 2,
+          borderRadius: kBr16,
+          clipBehavior: Clip.antiAlias,
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: InkWell(
+              focusColor: kIsWeb ? theme.focusColor : Colors.transparent,
+              hoverColor: kIsWeb ? theme.hoverColor : Colors.transparent,
+              borderRadius: kBr16,
+              canRequestFocus: !isLoading,
+              onTap: isLoading
+                  ? null
+                  : () {
+                      if (!kIsWeb) HapticFeedback.selectionClick();
+                      widget.onTap();
+                    },
+              onTapDown: (_) => _setPressed(true),
+              onTapCancel: () => _setPressed(false),
+              onTapUp: (_) => _setPressed(false),
+              child: Padding(
+                padding: kPad16,
+                child: Row(
+                  children: [
+                    leadingIcon,
+                    kGap16w,
+                    Expanded(
+                      child: _TitleAndSubtitle(
+                        title: widget.category.titlePlural,
+                        subtitle: widget.subtitle,
+                        isLoading: isLoading,
+                      ),
+                    ),
+                    AnimatedSwitcher(
+                      duration: kDurFast,
+                      transitionBuilder: (child, anim) =>
+                          FadeTransition(opacity: anim, child: child),
+                      child: trailingContent,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TitleAndSubtitle extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final bool isLoading;
+
+  const _TitleAndSubtitle({
+    required this.title,
+    required this.subtitle,
+    required this.isLoading,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    if (isLoading) {
+      return const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _SkeletonLine(widthFactor: 0.5),
+          kGap6,
+          _SkeletonLine(widthFactor: 0.35),
+        ],
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: textTheme.titleMedium,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 4),
+        AnimatedSwitcher(
+          duration: kDurFast,
+          transitionBuilder: (child, anim) =>
+              FadeTransition(opacity: anim, child: child),
+          child: Text(
+            subtitle,
+            key: ValueKey(subtitle),
+            style: textTheme.bodyMedium,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SkeletonLine extends StatelessWidget {
+  final double widthFactor;
+  const _SkeletonLine({required this.widthFactor});
+
+  @override
+  Widget build(BuildContext context) {
+    final base = Theme.of(context).colorScheme.surfaceContainerHighest;
+    return FractionallySizedBox(
+      widthFactor: widthFactor,
+      child: Container(
+        height: 16,
+        decoration: BoxDecoration(
+          color: base,
+          borderRadius: BorderRadius.circular(4),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,173 +1,25 @@
+library home_screen;
+
 import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:intl/intl.dart';
+import 'package:url_launcher/url_launcher.dart';
 
-import 'add_contact_screen.dart';
-import 'settings_screen.dart';
-import 'contact_list_screen.dart';
 import '../services/contact_database.dart';
 import '../widgets/system_notifications.dart';
+import 'add_contact_screen.dart';
+import 'contact_list_screen.dart';
+import 'settings_screen.dart';
 
-/// ---------------------
-/// Строки (русская локаль)
-/// ---------------------
-abstract class R {
-  static const appTitle = 'Touch NoteBook';
-  static const homeTitle = 'Главный экран';
-  static const settings = 'Настройки';
-  static const support = 'Поддержка';
-  static const addContact = 'Добавить контакт';
-  static const contactSaved = 'Контакт сохранён';
-  static const noContacts = 'Пока нет контактов';
-  static const noData = 'Нет данных';
-  static const loadError = 'Не удалось загрузить данные';
-  static const tryAgain = 'Повторить';
-  static const checkNetwork = 'Проверьте подключение к сети и попробуйте ещё раз.';
-  static const telegramNotInstalled = 'Telegram не установлен, откроем в браузере';
-  static const telegramOpenFailed = 'Не удалось открыть Telegram';
-  static const loading = 'Загрузка…';
-  static const unknown = 'Неизвестно';
-  static const qtyLabel = 'Количество';
-  static const summaryTitle = 'Сводка по контактам';
-  static const summaryKnownLabel = 'Всего известных контактов';
-  static const summaryAllKnown = 'Все категории синхронизированы';
-  static const quickActions = 'Быстрые действия';
-  static const linkCopied = 'Ссылка скопирована';
-  static const emptyStateHelp =
-      'Создайте первый контакт. Ниже можно открыть списки по категориям.';
-  static const chipHintOpenList = 'Откройте список по категории';
-  static const dataUpdated = 'Данные обновлены';
+part 'home/home_definitions.dart';
+part 'home/home_controller.dart';
+part 'home/home_actions.dart';
+part 'home/home_widgets.dart';
 
-  static String summaryUnknown(int count) {
-    if (count <= 0) return summaryAllKnown;
-    final noun = (count == 1) ? 'категории' : 'категориям';
-    return 'По $count\u00A0$noun пока нет данных';
-  }
-}
-
-/// ---------------------
-/// Константы оформления
-/// ---------------------
-const kPad16 = EdgeInsets.all(16);
-const kGap6 = SizedBox(height: 6);
-const kGap8 = SizedBox(height: 8);
-const kGap12 = SizedBox(height: 12);
-const kGap16w = SizedBox(width: 16);
-const kDurTap = Duration(milliseconds: 120);
-const kDurFast = Duration(milliseconds: 200);
-const kBr16 = BorderRadius.all(Radius.circular(16));
-
-EdgeInsets _listPadding(BuildContext context) {
-  // SafeArea уже обрабатывает системные отступы снизу.
-  const fabEstimatedHeight = 56.0; // высота FAB.extended
-  const bottom = 16 + kFloatingActionButtonMargin + fabEstimatedHeight;
-  return const EdgeInsets.fromLTRB(16, 16, 16, bottom);
-}
-
-/// Кешированный форматтер чисел для RU
-final NumberFormat _nfRu = NumberFormat.decimalPattern('ru');
-
-/// ---------------------
-/// Типобезопасные категории
-/// ---------------------
-enum ContactCategory { partner, client, prospect }
-
-extension ContactCategoryX on ContactCategory {
-  String get dbKey => switch (this) {
-    ContactCategory.partner => 'Партнёр',
-    ContactCategory.client => 'Клиент',
-    ContactCategory.prospect => 'Потенциальный',
-  };
-
-  String get titlePlural => switch (this) {
-    ContactCategory.partner => 'Партнёры',
-    ContactCategory.client => 'Клиенты',
-    ContactCategory.prospect => 'Потенциальные клиенты',
-  };
-
-  IconData get icon => switch (this) {
-    ContactCategory.partner => Icons.handshake,
-    ContactCategory.client => Icons.people,
-    ContactCategory.prospect => Icons.person_add_alt_1,
-  };
-
-  /// Склонение + неразрывный пробел
-  String russianCount(int count) {
-    if (count == 0) {
-      return switch (this) {
-        ContactCategory.partner => 'Нет партнёров',
-        ContactCategory.client => 'Нет клиентов',
-        ContactCategory.prospect => 'Нет потенциальных клиентов',
-      };
-    }
-    final m10 = count % 10;
-    final m100 = count % 100;
-
-    String pick({required String one, required String few, required String many}) {
-      final word = (m10 == 1 && m100 != 11)
-          ? one
-          : (m10 >= 2 && m10 <= 4 && (m100 < 10 || m100 >= 20))
-          ? few
-          : many;
-      return '${_nfRu.format(count)}\u00A0$word';
-    }
-
-    return switch (this) {
-      ContactCategory.partner =>
-          pick(one: 'партнёр', few: 'партнёра', many: 'партнёров'),
-      ContactCategory.client =>
-          pick(one: 'клиент', few: 'клиента', many: 'клиентов'),
-      ContactCategory.prospect => pick(
-        one: 'потенциальный клиент',
-        few: 'потенциальных клиента',
-        many: 'потенциальных клиентов',
-      ),
-    };
-  }
-}
-
-/// ---------------------
-/// Типобезопасные счётчики
-/// ---------------------
-class Counts {
-  final Map<ContactCategory, int> _m;
-  const Counts(this._m);
-
-  int of(ContactCategory c) => _m[c] ?? 0;
-
-  bool get allZero => ContactCategory.values.every((c) => of(c) == 0);
-
-  int get knownTotal {
-    return ContactCategory.values.fold<int>(0, (sum, c) {
-      final value = of(c);
-      return value >= 0 ? sum + value : sum;
-    });
-  }
-
-  int get unknownCount => ContactCategory.values.where((c) => of(c) < 0).length;
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other is! Counts) return false;
-    for (final c in ContactCategory.values) {
-      if (of(c) != other.of(c)) return false;
-    }
-    return true;
-  }
-
-  @override
-  int get hashCode => Object.hashAll(ContactCategory.values.map(of));
-}
-
-/// ---------------------
-/// Экран
-/// ---------------------
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
@@ -176,21 +28,12 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
+  late final HomeStateController _controller;
   late Future<Counts> _countsFuture;
-  late final VoidCallback _revListener;
-  bool _loadErrorShown = false;
-
-  // debounce для частых ревизий
-  Timer? _debounce;
-
-  // Для уведомления «Данные обновлены»
-  Counts? _lastCountsShown;
-
-  // Последние валидные данные для устойчивого UI во время refresh
-  Counts? _lastGoodCounts;
-
-  // Restoration
+  late final VoidCallback _removeRevisionListener;
   final RestorableInt _drawerIndex = RestorableInt(0);
+  final HomeActions _actions = const HomeActions();
+  bool _loadErrorShown = false;
 
   @override
   String? get restorationId => 'home_screen';
@@ -203,58 +46,29 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
   @override
   void initState() {
     super.initState();
-    _countsFuture = _loadCounts();
-    _revListener = _scheduleRefresh;
-    ContactDatabase.instance.revision.addListener(_revListener);
+    _controller = HomeStateController();
+    _countsFuture = _controller.loadCounts();
+    _removeRevisionListener =
+        _controller.listenForRevisionUpdates(_triggerRefreshCounts);
   }
 
   @override
   void dispose() {
-    _debounce?.cancel();
-    ContactDatabase.instance.revision.removeListener(_revListener);
+    _removeRevisionListener();
+    _controller.dispose();
     _drawerIndex.dispose();
     super.dispose();
   }
 
-  Future<int> _safe(Future<int> f) async {
-    try {
-      // если источник «подвис», через 3 сек показываем «Неизвестно»
-      return await f.timeout(const Duration(seconds: 3));
-    } catch (e, s) {
-      debugPrint('count error: $e\n$s');
-      return -1; // -1 = неизвестно
-    }
-  }
-
-  Future<Counts> _loadCounts() async {
-    final partner = await _safe(
-        ContactDatabase.instance.countByCategory(ContactCategory.partner.dbKey));
-    final client = await _safe(
-        ContactDatabase.instance.countByCategory(ContactCategory.client.dbKey));
-    final prospect = await _safe(
-        ContactDatabase.instance.countByCategory(ContactCategory.prospect.dbKey));
-    return Counts({
-      ContactCategory.partner: partner,
-      ContactCategory.client: client,
-      ContactCategory.prospect: prospect,
-    });
-  }
-
-  void _scheduleRefresh() {
-    _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 200), () {
-      if (!mounted) return;
-      setState(() {
-        _countsFuture = _loadCounts();
-      });
+  void _triggerRefreshCounts() {
+    if (!mounted) return;
+    setState(() {
+      _countsFuture = _controller.loadCounts();
     });
   }
 
   Future<void> _refresh() async {
-    if (!mounted) return;
-    setState(() {
-      _countsFuture = _loadCounts();
-    });
+    _triggerRefreshCounts();
   }
 
   void _showLoadErrorOnce(BuildContext context) {
@@ -266,100 +80,14 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
     _loadErrorShown = true;
   }
 
-  Future<void> _openSupport(BuildContext context) async {
-    const group = 'touchnotebook';
-    final tgUri = Uri.parse('tg://resolve?domain=$group');
-    final webUri = Uri.parse('https://t.me/$group');
-    try {
-      if (kIsWeb) {
-        await launchUrl(webUri, mode: LaunchMode.platformDefault);
-        return;
-      }
-      if (await canLaunchUrl(tgUri)) {
-        await launchUrl(tgUri, mode: LaunchMode.externalApplication);
-      } else {
-        if (!mounted) return;
-        showWarningBanner(R.telegramNotInstalled);
-        await launchUrl(webUri, mode: LaunchMode.externalApplication);
-      }
-    } catch (e, s) {
-      debugPrint('openSupport error: $e\n$s');
-      if (!mounted) return;
-      showErrorBanner(R.telegramOpenFailed);
-      // мягкий fallback — скопируем ссылку
-      await Clipboard.setData(
-        const ClipboardData(text: 'https://t.me/touchnotebook'),
-      );
-      if (!mounted) return;
-      showInfoBanner(R.linkCopied);
-    }
-  }
+  Future<void> _openSupport() => _actions.openSupport(context);
 
-  Future<void> _openAddContact(BuildContext context) async {
-    if (!kIsWeb) HapticFeedback.selectionClick();
-    final saved = await Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => const AddContactScreen()),
-    );
-    if (saved == true && mounted) {
-      showSuccessBanner(R.contactSaved);
-    }
-  }
+  Future<void> _openAddContact() => _actions.openAddContact(context);
 
-  /// Определяем количество колонок для адаптива
-  int _calcColumns(BoxConstraints c) {
-    final w = c.maxWidth;
-    if (w >= 1200) return 3;
-    if (w >= 800) return 2;
-    return 1;
-  }
+  void _openSettings() => _actions.openSettings(context);
 
-  double _gridChildAspectRatio(
-      BoxConstraints constraints,
-      int cols,
-      EdgeInsets listPadding,
-      ) {
-    final horizontalPadding = listPadding.left + listPadding.right;
-    const spacing = 12.0;
-    final totalSpacing = horizontalPadding + spacing * (cols - 1);
-    final availableWidth = constraints.maxWidth - totalSpacing;
-    final cellWidth = availableWidth <= 0 ? 1.0 : availableWidth / cols;
-    final viewportHeight = constraints.maxHeight;
-    final baseHeight = cellWidth / 1.9; // умеренно широкие карточки
-    const minHeight = 140.0;
-    final fallbackMaxHeight = cellWidth * 1.1;
-    final maxHeight = viewportHeight.isFinite
-        ? math.max(minHeight, viewportHeight * 0.6)
-        : fallbackMaxHeight;
-    final cellHeight = baseHeight.clamp(minHeight, maxHeight).toDouble();
-    return cellWidth / cellHeight;
-  }
-
-  void _maybeNotifyUpdated(Counts newCounts) {
-    final last = _lastCountsShown;
-    if (last == null) {
-      _lastCountsShown = newCounts;
-      // кэшируем «хорошие» данные
-      if (newCounts.unknownCount == 0 || newCounts.knownTotal > 0) {
-        _lastGoodCounts = newCounts;
-      }
-      return;
-    }
-
-    // уведомляем, если ранее были неизвестные и стало меньше неизвестных
-    if (last.unknownCount > 0 && newCounts.unknownCount < last.unknownCount) {
-      showInfoBanner(
-        R.dataUpdated,
-        duration: const Duration(milliseconds: 1500),
-      );
-    }
-    _lastCountsShown = newCounts;
-
-    // обновим кэш «хороших» данных
-    if (newCounts.unknownCount == 0 || newCounts.knownTotal > 0) {
-      _lastGoodCounts = newCounts;
-    }
-  }
+  void _openCategory(ContactCategory category) =>
+      _actions.openCategoryList(context, category);
 
   @override
   Widget build(BuildContext context) {
@@ -373,13 +101,10 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
           Navigator.pop(context);
           switch (index) {
             case 1:
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const SettingsScreen()),
-              );
+              _openSettings();
               break;
             case 2:
-              _openSupport(context);
+              _openSupport();
               break;
             default:
               break;
@@ -409,15 +134,13 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
           child: FutureBuilder<Counts>(
             future: _countsFuture,
             builder: (context, snapshot) {
-              final waiting = snapshot.connectionState == ConnectionState.waiting;
-              final hasSomeData = snapshot.hasData || _lastGoodCounts != null;
+              final waiting =
+                  snapshot.connectionState == ConnectionState.waiting;
+              final hasSomeData =
+                  snapshot.hasData || _controller.lastGoodCounts != null;
 
-              // если есть хоть какие-то прошлые данные — используем их
-              final counts = snapshot.data ??
-                  _lastGoodCounts ??
-                  Counts({ for (final c in ContactCategory.values) c: 0 });
+              final counts = _controller.effectiveCounts(snapshot);
 
-              // если пришла ошибка и данных нет вообще — показываем карточку ошибки
               if (snapshot.hasError && !hasSomeData) {
                 debugPrint(
                   'Error loading contact counts: ${snapshot.error}\n${snapshot.stackTrace}',
@@ -426,26 +149,34 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
                 return ListView(
                   key: const PageStorageKey('home-error-list'),
                   physics: const AlwaysScrollableScrollPhysics(),
-                  padding: _listPadding(context),
-                  children: const [ _ErrorCard(onRetry: null) ],
+                  padding: homeListPadding(context),
+                  children: const [
+                    _ErrorCard(onRetry: null),
+                  ],
                 );
               }
 
               _loadErrorShown = false;
 
-              // уведомим об обновлении (после кадра)
               WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (mounted && snapshot.hasData) _maybeNotifyUpdated(snapshot.data!);
+                if (!mounted || !snapshot.hasData) return;
+                final shouldNotify =
+                    _controller.registerCounts(snapshot.data!);
+                if (shouldNotify) {
+                  showInfoBanner(
+                    R.dataUpdated,
+                    duration: const Duration(milliseconds: 1500),
+                  );
+                }
               });
 
               final isInitialLoad = !hasSomeData && waiting;
 
-              // Первичная загрузка — скромный placeholder
               if (isInitialLoad) {
                 return ListView(
                   key: const PageStorageKey('home-initial-loading'),
                   physics: const AlwaysScrollableScrollPhysics(),
-                  padding: _listPadding(context),
+                  padding: homeListPadding(context),
                   children: const [
                     _SkeletonLine(widthFactor: 0.9),
                     SizedBox(height: 12),
@@ -456,35 +187,25 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
                 );
               }
 
-              // Основной список/сетка
-              final showSummary = !counts.allZero; // сводка остаётся при refresh
-              final listPadding = _listPadding(context);
+              final showSummary = !counts.allZero;
+              final listPadding = homeListPadding(context);
 
               return LayoutBuilder(
                 builder: (context, constraints) {
-                  final cols = _calcColumns(constraints);
+                  final cols = calcColumns(constraints);
 
                   final items = ContactCategory.values.map((cat) {
                     final c = counts.of(cat);
-                    final subtitle = (c < 0) ? R.unknown : cat.russianCount(c);
-                    final chip = (c < 0) ? '—' : _nfRu.format(c);
+                    final subtitle =
+                        (c < 0) ? R.unknown : cat.russianCount(c);
+                    final chip =
+                        (c < 0) ? '—' : homeNumberFormat.format(c);
                     return _CategoryCard(
                       category: cat,
                       subtitle: subtitle,
                       trailingCount: chip,
-                      isLoading: false, // НЕ скрываем карточки при refresh
-                      onTap: () {
-                        if (!kIsWeb) HapticFeedback.selectionClick();
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => ContactListScreen(
-                              category: cat.dbKey,
-                              title: cat.titlePlural,
-                            ),
-                          ),
-                        );
-                      },
+                      isLoading: false,
+                      onTap: () => _openCategory(cat),
                     );
                   }).toList(growable: false);
 
@@ -496,31 +217,20 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
                         padding: listPadding,
                         itemCount: items.length + (showSummary ? 1 : 0),
                         separatorBuilder: (_, __) => const SizedBox(height: 12),
-                        itemBuilder: (_, i) {
-                          if (showSummary && i == 0) {
+                        itemBuilder: (_, index) {
+                          if (showSummary && index == 0) {
                             return _SummaryCard(
                               knownTotal: counts.knownTotal,
                               unknownCount: counts.unknownCount,
-                              onAddContact: () => _openAddContact(context),
-                              onOpenSettings: () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (_) => const SettingsScreen(),
-                                  ),
-                                );
-                              },
-                              onOpenSupport: () => _openSupport(context),
                             );
                           }
-                          final index = showSummary ? i - 1 : i;
-                          return items[index];
+                          final itemIndex = showSummary ? index - 1 : index;
+                          return items[itemIndex];
                         },
                       ),
                     );
                   }
 
-                  // 2–3 колонки (планшет/desktop/web)
                   return Scrollbar(
                     thumbVisibility: true,
                     child: CustomScrollView(
@@ -539,16 +249,6 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
                               child: _SummaryCard(
                                 knownTotal: counts.knownTotal,
                                 unknownCount: counts.unknownCount,
-                                onAddContact: () => _openAddContact(context),
-                                onOpenSettings: () {
-                                  Navigator.push(
-                                    context,
-                                    MaterialPageRoute(
-                                      builder: (_) => const SettingsScreen(),
-                                    ),
-                                  );
-                                },
-                                onOpenSupport: () => _openSupport(context),
                               ),
                             ),
                           ),
@@ -564,11 +264,12 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
                               (_, i) => RepaintBoundary(child: items[i]),
                               childCount: items.length,
                             ),
-                            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                            gridDelegate:
+                                SliverGridDelegateWithFixedCrossAxisCount(
                               crossAxisCount: cols,
                               mainAxisSpacing: 12,
                               crossAxisSpacing: 12,
-                              childAspectRatio: _gridChildAspectRatio(
+                              childAspectRatio: gridChildAspectRatio(
                                 constraints,
                                 cols,
                                 listPadding,
@@ -587,411 +288,9 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
       ),
       floatingActionButton: FloatingActionButton.extended(
         tooltip: R.addContact,
-        onPressed: () => _openAddContact(context),
+        onPressed: _openAddContact,
         label: const Text(R.addContact),
         icon: const Icon(Icons.person_add),
-      ),
-    );
-  }
-}
-
-/// ---------------------
-/// Виджеты
-/// ---------------------
-
-class _EmptyStateCard extends StatelessWidget {
-  const _EmptyStateCard();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Card(
-      child: Padding(
-        padding: kPad16,
-        child: Column(
-          children: [
-            Icon(Icons.person_off, size: 40),
-            kGap8,
-            Text(R.noContacts),
-            kGap8,
-            Text(
-              R.emptyStateHelp,
-              textAlign: TextAlign.center,
-            ),
-            kGap8,
-            _AddContactButton(),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _AddContactButton extends StatelessWidget {
-  const _AddContactButton();
-
-  @override
-  Widget build(BuildContext context) {
-    return FilledButton.icon(
-      onPressed: () {
-        final state = context.findAncestorStateOfType<_HomeScreenState>();
-        state?._openAddContact(context);
-      },
-      icon: const Icon(Icons.person_add),
-      label: const Text(R.addContact),
-    );
-  }
-}
-
-class _SummaryCard extends StatelessWidget {
-  final int knownTotal;
-  final int unknownCount;
-  final VoidCallback onAddContact;
-  final VoidCallback onOpenSettings;
-  final VoidCallback onOpenSupport;
-
-  const _SummaryCard({
-    required this.knownTotal,
-    required this.unknownCount,
-    required this.onAddContact,
-    required this.onOpenSettings,
-    required this.onOpenSupport,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final textTheme = theme.textTheme;
-    final colorScheme = theme.colorScheme;
-    final hasUnknown = unknownCount > 0;
-
-    return Card(
-      child: Padding(
-        padding: kPad16,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(R.summaryTitle, style: textTheme.titleMedium),
-            kGap8,
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        R.summaryKnownLabel,
-                        style: textTheme.labelMedium?.copyWith(
-                          color: colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        _nfRu.format(knownTotal),
-                        style: textTheme.headlineMedium
-                            ?.copyWith(fontWeight: FontWeight.w700),
-                      ),
-                    ],
-                  ),
-                ),
-                if (hasUnknown)
-                  Semantics(
-                    label: 'Есть неизвестные категории',
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: 12, top: 4),
-                      child: Icon(Icons.info_outline,
-                          color: colorScheme.secondary),
-                    ),
-                  ),
-              ],
-            ),
-            kGap8,
-            Text(
-              hasUnknown ? R.summaryUnknown(unknownCount) : R.summaryAllKnown,
-              style: textTheme.bodyMedium
-                  ?.copyWith(color: colorScheme.onSurfaceVariant),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _ErrorCard extends StatefulWidget {
-  final Future<void> Function()? onRetry;
-  const _ErrorCard({super.key, required this.onRetry});
-
-  @override
-  State<_ErrorCard> createState() => _ErrorCardState();
-}
-
-class _ErrorCardState extends State<_ErrorCard> {
-  bool _busy = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final onRetry = widget.onRetry;
-    return Card(
-      child: Padding(
-        padding: kPad16,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(R.loadError, style: TextStyle(fontWeight: FontWeight.w600)),
-            kGap8,
-            const Text(R.checkNetwork),
-            kGap8,
-            FilledButton.icon(
-              onPressed: _busy || onRetry == null
-                  ? null
-                  : () async {
-                setState(() => _busy = true);
-                await onRetry();
-                if (mounted) setState(() => _busy = false);
-              },
-              icon: _busy
-                  ? const SizedBox(
-                width: 18,
-                height: 18,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              )
-                  : const Icon(Icons.refresh),
-              label: Text(_busy ? R.loading : R.tryAgain),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _CategoryCard extends StatefulWidget {
-  final ContactCategory category;
-  final String subtitle;
-  final String? trailingCount; // null — без чипа (скелетон/загрузка)
-  final VoidCallback onTap;
-  final bool isLoading;
-
-  const _CategoryCard({
-    super.key,
-    required this.category,
-    required this.subtitle,
-    required this.onTap,
-    required this.trailingCount,
-    this.isLoading = false,
-  });
-
-  const _CategoryCard.loading({super.key, required ContactCategory category})
-      : category = category,
-        subtitle = R.loading,
-        trailingCount = null,
-        onTap = _noop,
-        isLoading = true;
-
-  static void _noop() {}
-  @override
-  State<_CategoryCard> createState() => _CategoryCardState();
-}
-
-class _CategoryCardState extends State<_CategoryCard> {
-  bool _pressed = false;
-
-  void _setPressed(bool value) {
-    if (widget.isLoading || _pressed == value) return;
-    setState(() => _pressed = value);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final isLoading = widget.isLoading;
-
-    Widget leadingIcon =
-    Icon(widget.category.icon, size: 32, color: colorScheme.primary);
-
-    if (!isLoading) {
-      leadingIcon = Hero(
-        tag: 'cat:${widget.category.dbKey}',
-        transitionOnUserGestures: true,
-        flightShuttleBuilder: (ctx, anim, dir, fromCtx, toCtx) {
-          return ScaleTransition(
-            scale: anim
-                .drive(Tween(begin: 0.9, end: 1.0).chain(CurveTween(curve: Curves.easeOut))),
-            child:
-            Icon(widget.category.icon, size: 32, color: colorScheme.primary),
-          );
-        },
-        child: leadingIcon,
-      );
-    }
-
-    final String? countStr = widget.trailingCount;
-    final bool isUnknown = countStr == '—';
-
-    final Widget trailingContent = countStr == null
-        ? const Icon(Icons.chevron_right)
-        : Row(
-      key: ValueKey(countStr), // ключ для AnimatedSwitcher
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Tooltip(
-          message: isUnknown
-              ? 'Количество неизвестно — данные обновятся автоматически'
-              : '${R.qtyLabel}: $countStr',
-          child: Semantics(
-            label:
-            '${widget.category.titlePlural}: ${R.qtyLabel.toLowerCase()}',
-            value: isUnknown ? R.unknown : countStr,
-            hint: '${R.chipHintOpenList}: ${widget.category.titlePlural}',
-            child: Chip(
-              label: Text(
-                countStr,
-                style: const TextStyle(fontWeight: FontWeight.w600),
-              ),
-              backgroundColor: isUnknown
-                  ? colorScheme.surfaceVariant
-                  : colorScheme.primaryContainer,
-              side: BorderSide(
-                color: isUnknown
-                    ? colorScheme.outline
-                    : colorScheme.outlineVariant,
-              ),
-              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              visualDensity: VisualDensity.compact,
-            ),
-          ),
-        ),
-        const Icon(Icons.chevron_right),
-      ],
-    );
-
-    return Semantics(
-      button: true,
-      label: widget.category.titlePlural,
-      value: widget.subtitle,
-      child: AnimatedScale(
-        scale: _pressed ? 0.985 : 1.0,
-        duration: kDurTap,
-        child: Material(
-          color: theme.colorScheme.surfaceContainerHigh, // контрастнее, чем surfaceVariant
-          elevation: 2,
-          borderRadius: kBr16,
-          clipBehavior: Clip.antiAlias,
-          child: MouseRegion(
-            cursor: SystemMouseCursors.click,
-            child: InkWell(
-              focusColor: kIsWeb ? theme.focusColor : Colors.transparent,
-              hoverColor: kIsWeb ? theme.hoverColor : Colors.transparent,
-              borderRadius: kBr16,
-              canRequestFocus: !isLoading,
-              onTap: isLoading
-                  ? null
-                  : () {
-                if (!kIsWeb) HapticFeedback.selectionClick();
-                widget.onTap();
-              },
-              onTapDown: (_) => _setPressed(true),
-              onTapCancel: () => _setPressed(false),
-              onTapUp: (_) => _setPressed(false),
-              child: Padding(
-                padding: kPad16,
-                child: Row(
-                  children: [
-                    leadingIcon,
-                    kGap16w,
-                    Expanded(
-                      child: _TitleAndSubtitle(
-                        title: widget.category.titlePlural,
-                        subtitle: widget.subtitle,
-                        isLoading: isLoading,
-                      ),
-                    ),
-                    AnimatedSwitcher(
-                      duration: kDurFast,
-                      transitionBuilder: (child, anim) =>
-                          FadeTransition(opacity: anim, child: child),
-                      child: trailingContent,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Заголовок/подзаголовок с простым скелетоном (без пакетов)
-class _TitleAndSubtitle extends StatelessWidget {
-  final String title;
-  final String subtitle;
-  final bool isLoading;
-
-  const _TitleAndSubtitle({
-    required this.title,
-    required this.subtitle,
-    required this.isLoading,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-
-    if (isLoading) {
-      return const Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _SkeletonLine(widthFactor: 0.5),
-          kGap6,
-          _SkeletonLine(widthFactor: 0.35),
-        ],
-      );
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(title,
-            style: textTheme.titleMedium,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis),
-        const SizedBox(height: 4),
-        AnimatedSwitcher(
-          duration: kDurFast,
-          transitionBuilder: (child, anim) =>
-              FadeTransition(opacity: anim, child: child),
-          child: Text(
-            subtitle,
-            key: ValueKey(subtitle),
-            style: textTheme.bodyMedium,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _SkeletonLine extends StatelessWidget {
-  final double widthFactor;
-  const _SkeletonLine({required this.widthFactor});
-
-  @override
-  Widget build(BuildContext context) {
-    final base = Theme.of(context).colorScheme.surfaceContainerHighest;
-    return FractionallySizedBox(
-      widthFactor: widthFactor,
-      child: Container(
-        height: 16,
-        decoration: BoxDecoration(
-          color: base,
-          borderRadius: BorderRadius.circular(4),
-        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- modularize the home screen into dedicated parts for definitions, controller logic, navigation actions, and reusable widgets
- add a state controller and preview widget for the add contact flow, replacing the monolithic state with accessor helpers
- update the add contact UI to consume the shared controller for pickers, preview, and tag handling

## Testing
- Not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d458ec06908328b00173cd32e880dc