### PR TITLE
Schedule real notifications for contact reminders

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 import 'app.dart';
+import 'services/reminder_scheduler.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await ReminderScheduler.instance.ensureInitialized();
   runApp(const App());
 }
 

--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -1,0 +1,53 @@
+class Reminder {
+  final int? id;
+  final int contactId;
+  final String title;
+  final DateTime remindAt;
+  final bool isCompleted;
+  final DateTime createdAt;
+
+  const Reminder({
+    this.id,
+    required this.contactId,
+    required this.title,
+    required this.remindAt,
+    this.isCompleted = false,
+    required this.createdAt,
+  });
+
+  Reminder copyWith({
+    int? id,
+    int? contactId,
+    String? title,
+    DateTime? remindAt,
+    bool? isCompleted,
+    DateTime? createdAt,
+  }) {
+    return Reminder(
+      id: id ?? this.id,
+      contactId: contactId ?? this.contactId,
+      title: title ?? this.title,
+      remindAt: remindAt ?? this.remindAt,
+      isCompleted: isCompleted ?? this.isCompleted,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'contactId': contactId,
+        'title': title,
+        'remindAt': remindAt.millisecondsSinceEpoch,
+        'isCompleted': isCompleted ? 1 : 0,
+        'createdAt': createdAt.millisecondsSinceEpoch,
+      };
+
+  factory Reminder.fromMap(Map<String, dynamic> map) => Reminder(
+        id: map['id'] as int?,
+        contactId: map['contactId'] as int,
+        title: map['title'] as String,
+        remindAt: DateTime.fromMillisecondsSinceEpoch(map['remindAt'] as int),
+        isCompleted: (map['isCompleted'] as int? ?? 0) == 1,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+      );
+}

--- a/lib/screens/add_reminder_screen.dart
+++ b/lib/screens/add_reminder_screen.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+import '../services/reminder_scheduler.dart';
+
+class AddReminderScreen extends StatefulWidget {
+  final int contactId;
+  final Reminder? initial;
+
+  const AddReminderScreen({super.key, required this.contactId, this.initial});
+
+  bool get isEditing => initial != null;
+
+  @override
+  State<AddReminderScreen> createState() => _AddReminderScreenState();
+}
+
+class _AddReminderScreenState extends State<AddReminderScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  late DateTime _remindAt;
+  bool _isCompleted = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initial;
+    if (initial != null) {
+      _titleController.text = initial.title;
+      _remindAt = initial.remindAt;
+      _isCompleted = initial.isCompleted;
+    } else {
+      final now = DateTime.now();
+      _remindAt = now.add(const Duration(hours: 1));
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  InputDecoration _outlinedDec({
+    required String label,
+    String? hint,
+    IconData? prefixIcon,
+  }) {
+    final theme = Theme.of(context);
+    return InputDecoration(
+      labelText: label,
+      hintText: hint,
+      prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
+      border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: theme.dividerColor),
+      ),
+      isDense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+    );
+  }
+
+  Widget _sectionCard({required String title, required List<Widget> children}) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      margin: const EdgeInsets.only(bottom: 16),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 12),
+            ...children,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _borderedTile({required Widget child}) {
+    final theme = Theme.of(context);
+    return Material(
+      color: Colors.transparent,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      clipBehavior: Clip.antiAlias,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: theme.dividerColor),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: child,
+      ),
+    );
+  }
+
+  Future<void> _pickDateTime() async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: _remindAt,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+      locale: const Locale('ru'),
+    );
+    if (date == null) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(_remindAt),
+      builder: (context, child) {
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),
+          child: child ?? const SizedBox.shrink(),
+        );
+      },
+    );
+    if (time == null) return;
+
+    setState(() {
+      _remindAt = DateTime(date.year, date.month, date.day, time.hour, time.minute);
+    });
+  }
+
+  bool get _canSave => (_formKey.currentState?.validate() ?? false);
+
+  Future<void> _save() async {
+    if (!_canSave) return;
+
+    final reminder = Reminder(
+      id: widget.initial?.id,
+      contactId: widget.contactId,
+      title: _titleController.text.trim(),
+      remindAt: _remindAt,
+      isCompleted: _isCompleted,
+      createdAt: widget.initial?.createdAt ?? DateTime.now(),
+    );
+
+    if (widget.isEditing) {
+      await ContactDatabase.instance.updateReminder(reminder);
+      await ReminderScheduler.instance.scheduleReminder(reminder);
+      if (!mounted) return;
+      Navigator.pop(context, reminder);
+    } else {
+      final id = await ContactDatabase.instance.insertReminder(reminder);
+      final saved = reminder.copyWith(id: id);
+      await ReminderScheduler.instance.scheduleReminder(saved);
+      if (!mounted) return;
+      Navigator.pop(context, saved);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = widget.isEditing ? 'Изменить напоминание' : 'Добавить напоминание';
+    final dateStr = DateFormat('dd.MM.yyyy HH:mm').format(_remindAt);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          tooltip: 'Отмена',
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(title),
+        actions: [
+          if (_canSave)
+            IconButton(
+              tooltip: 'Сохранить',
+              icon: const Icon(Icons.check),
+              onPressed: _save,
+            )
+          else
+            const SizedBox.shrink(),
+        ],
+      ),
+      body: SafeArea(
+        child: GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          behavior: HitTestBehavior.opaque,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              child: ListView(
+                children: [
+                  _sectionCard(
+                    title: 'Описание',
+                    children: [
+                      TextFormField(
+                        controller: _titleController,
+                        minLines: 1,
+                        maxLines: 2,
+                        textInputAction: TextInputAction.done,
+                        decoration: _outlinedDec(
+                          label: 'Текст напоминания',
+                          hint: 'О чём нужно напомнить',
+                          prefixIcon: Icons.alarm,
+                        ),
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return 'Введите текст напоминания';
+                          }
+                          return null;
+                        },
+                      ),
+                    ],
+                  ),
+                  _sectionCard(
+                    title: 'Когда напомнить',
+                    children: [
+                      _borderedTile(
+                        child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+                          leading: const Icon(Icons.event_available),
+                          title: Text(dateStr),
+                          subtitle: const Text('Нажмите, чтобы выбрать дату и время'),
+                          onTap: _pickDateTime,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      _borderedTile(
+                        child: SwitchListTile(
+                          title: const Text('Пометка выполнено'),
+                          value: _isCompleted,
+                          onChanged: (value) => setState(() => _isCompleted = value),
+                          secondary: const Icon(Icons.check_circle_outline),
+                          contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _canSave ? _save : null,
+        icon: const Icon(Icons.check),
+        label: const Text('Сохранить'),
+      ),
+    );
+  }
+}

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -8,10 +8,14 @@ import 'package:overlay_support/overlay_support.dart';
 
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
 import '../services/contact_database.dart';
+import '../services/reminder_scheduler.dart';
 import '../widgets/system_notifications.dart';
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
+import 'add_reminder_screen.dart';
+import 'reminders_list_screen.dart';
 import 'contact_list_screen.dart';
 
 class ContactDetailsScreen extends StatefulWidget {
@@ -51,6 +55,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   // --- keys для автоскролла к самим карточкам ---
   final _extraCardKey = GlobalKey();
+  final _remindersCardKey = GlobalKey();
   final _notesCardKey = GlobalKey();
 
   IconData _statusIcon(String s) {
@@ -62,6 +67,45 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       case 'Тёплый':     return Icons.local_fire_department;
       default:           return Icons.label_outline;
     }
+  }
+
+  Widget _reminderRow(Reminder reminder, {bool isLast = false}) {
+    final theme = Theme.of(context);
+    final dateStr = DateFormat('dd.MM.yyyy HH:mm').format(reminder.remindAt);
+    final statusColor = reminder.isCompleted
+        ? theme.colorScheme.primary
+        : theme.colorScheme.secondary;
+    final statusLabel = reminder.isCompleted ? 'Выполнено' : 'Напоминание';
+
+    return _sheetRow(
+      leading: Icon(
+        reminder.isCompleted ? Icons.check_circle_outline : Icons.alarm_outlined,
+        color: statusColor,
+      ),
+      right: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            reminder.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodyLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            dateStr,
+            style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            statusLabel,
+            style: theme.textTheme.bodySmall?.copyWith(color: statusColor),
+          ),
+        ],
+      ),
+      onTap: null,
+      isLast: isLast,
+    );
   }
 
   Widget _noteRow(Note note, {bool isLast = false}) {
@@ -503,7 +547,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   bool _addedOpen = false;
 
   bool _extraExpanded = false; // «Дополнительно»
+  bool _remindersExpanded = true; // «Напоминания» открыто
   bool _notesExpanded = true; // «Заметки» открыто
+  List<Reminder> _reminders = [];
   List<Note> _notes = [];
 
   // FocusNodes — для подсветки/навигации
@@ -548,6 +594,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     super.initState();
     _contact = widget.contact;
     _loadFromContact();
+    _loadReminders();
     _loadNotes();
     // чтобы превью обновлялось при каждом символе
     _phoneController.addListener(() => setState(() {}));
@@ -580,6 +627,21 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     super.dispose();
   }
 
+  Future<void> _loadReminders() async {
+    if (_contact.id == null) return;
+    final reminders = await ContactDatabase.instance.remindersByContact(_contact.id!);
+    if (!mounted) return;
+    final active = reminders.where((r) => !r.isCompleted).toList();
+    final preview = <Reminder>[];
+    preview.addAll(active.take(3));
+    if (preview.length < 3) {
+      preview.addAll(
+        reminders.where((r) => r.isCompleted).take(3 - preview.length),
+      );
+    }
+    setState(() => _reminders = preview);
+  }
+
   Future<void> _loadNotes() async {
     if (_contact.id == null) return;
     final notes = await ContactDatabase.instance.lastNotesByContact(_contact.id!, limit: 3);
@@ -598,6 +660,21 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       await _loadNotes();
       if (!mounted) return;
       showSuccessBanner('Заметка добавлена');
+    }
+  }
+
+  Future<void> _addReminder() async {
+    if (_contact.id == null) return;
+    final reminder = await Navigator.push<Reminder>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => AddReminderScreen(contactId: _contact.id!),
+      ),
+    );
+    if (reminder != null) {
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание добавлено');
     }
   }
 
@@ -1072,8 +1149,11 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
     final db = ContactDatabase.instance;
 
-    // Удаляем контакт и забираем снапшот заметок для возможного Undo
-    final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
+    // Удаляем контакт и забираем снапшот связанных данных для Undo
+    final snapshot = await db.deleteContactWithSnapshot(c.id!);
+    await ReminderScheduler.instance.cancelMany(
+      snapshot.reminders.where((r) => r.id != null).map((r) => r.id!),
+    );
 
     // Показываем баннер с Undo
     _undoBanner?.dismiss();
@@ -1084,14 +1164,23 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       icon: Icons.delete_outline,
       onUndo: () async {
         _undoBanner = null;
-        final newId = await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+        final newId = await db.restoreContactWithNotes(
+          c.copyWith(id: null),
+          snapshot.notes,
+          reminders: snapshot.reminders,
+        );
+        final restoredReminders = await db.remindersByContact(newId);
+        await ReminderScheduler.instance.scheduleMany(
+          restoredReminders.where((r) => !r.isCompleted),
+          contactName: c.name,
+        );
 
         // Сообщаем открытому списку: локально добавить и подсветить (без автоскролла)
         ContactListScreen.notifyRestoredIfMounted(c, newId);
         showSystemNotification(
-        'Контакт восстановлен',
-        style: SystemNotificationStyle.success,
-        iconOverride: Icons.undo,
+          'Контакт восстановлен',
+          style: SystemNotificationStyle.success,
+          iconOverride: Icons.undo,
         );
       },
     );
@@ -1609,6 +1698,91 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     // Соцсеть — верхний хинт показываем, если пусто
                     _socialPickerField(),
                   ],
+                ),
+              ),
+
+              // ===== Блок: Напоминания =====
+              KeyedSubtree(
+                key: _remindersCardKey,
+                child: _collapsibleSectionCard(
+                  title: 'Напоминания',
+                  expanded: _remindersExpanded,
+                  onChanged: (v) {
+                    setState(() => _remindersExpanded = v);
+                    if (v) _scrollToCard(_remindersCardKey);
+                  },
+                  headerActions: [
+                    TextButton(
+                      onPressed: _contact.id == null
+                          ? null
+                          : () async {
+                              await Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) => RemindersListScreen(
+                                    contact: _contact,
+                                    onRemindersChanged: _loadReminders,
+                                  ),
+                                ),
+                              );
+                              await _loadReminders();
+                            },
+                      child: const Text('Все напоминания'),
+                    ),
+                  ],
+                  children: _reminders.isEmpty
+                      ? [
+                          Card(
+                            elevation: 0,
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(
+                                    Icons.alarm_outlined,
+                                    size: 48,
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Text(
+                                    'Нет напоминаний',
+                                    style: Theme.of(context).textTheme.titleMedium,
+                                    textAlign: TextAlign.center,
+                                  ),
+                                  const SizedBox(height: 24),
+                                  FilledButton.icon(
+                                    onPressed: _contact.id == null ? null : _addReminder,
+                                    icon: const Icon(Icons.add_alarm),
+                                    label: const Text('Добавить напоминание'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ]
+                      : [
+                          Card(
+                            elevation: 0,
+                            child: Column(
+                              children: [
+                                for (var i = 0; i < _reminders.length; i++)
+                                  _reminderRow(
+                                    _reminders[i],
+                                    isLast: i == _reminders.length - 1,
+                                  ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: FilledButton.icon(
+                              onPressed: _contact.id == null ? null : _addReminder,
+                              icon: const Icon(Icons.add_alarm),
+                              label: const Text('Добавить напоминание'),
+                            ),
+                          ),
+                        ],
                 ),
               ),
 

--- a/lib/screens/reminders_list_screen.dart
+++ b/lib/screens/reminders_list_screen.dart
@@ -1,0 +1,269 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../models/contact.dart';
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+import '../services/reminder_scheduler.dart';
+import 'add_reminder_screen.dart';
+import '../widgets/system_notifications.dart';
+
+class RemindersListScreen extends StatefulWidget {
+  final Contact contact;
+  final Future<void> Function()? onRemindersChanged;
+
+  const RemindersListScreen({
+    super.key,
+    required this.contact,
+    this.onRemindersChanged,
+  });
+
+  @override
+  State<RemindersListScreen> createState() => _RemindersListScreenState();
+}
+
+class _RemindersListScreenState extends State<RemindersListScreen> {
+  final _db = ContactDatabase.instance;
+  List<Reminder> _reminders = [];
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadReminders();
+  }
+
+  Future<void> _loadReminders() async {
+    if (widget.contact.id == null) return;
+    setState(() => _isLoading = true);
+    try {
+      final list = await _db.remindersByContact(widget.contact.id!);
+      await ReminderScheduler.instance.scheduleMany(
+        list.where((r) => !r.isCompleted),
+        contactName: widget.contact.name,
+      );
+      if (!mounted) return;
+      setState(() {
+        _reminders = list;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isLoading = false);
+      showErrorBanner('Не удалось загрузить напоминания');
+    }
+  }
+
+  Future<void> _notifyParent() async {
+    final callback = widget.onRemindersChanged;
+    if (callback != null) {
+      await callback();
+    }
+  }
+
+  Future<void> _addReminder() async {
+    if (widget.contact.id == null) return;
+    final reminder = await Navigator.push<Reminder>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => AddReminderScreen(contactId: widget.contact.id!),
+      ),
+    );
+    if (reminder != null) {
+      await _loadReminders();
+      await _notifyParent();
+      showSuccessBanner('Напоминание добавлено');
+    }
+  }
+
+  Future<void> _editReminder(Reminder reminder) async {
+    if (widget.contact.id == null || reminder.id == null) return;
+    final updated = await Navigator.push<Reminder>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => AddReminderScreen(
+          contactId: widget.contact.id!,
+          initial: reminder,
+        ),
+      ),
+    );
+    if (updated != null) {
+      await _loadReminders();
+      await _notifyParent();
+      showSuccessBanner('Напоминание обновлено');
+    }
+  }
+
+  Future<void> _toggleCompleted(Reminder reminder) async {
+    final updated = reminder.copyWith(isCompleted: !reminder.isCompleted);
+    try {
+      await _db.updateReminder(updated);
+      await ReminderScheduler.instance.scheduleReminder(
+        updated,
+        contactName: widget.contact.name,
+      );
+      if (!mounted) return;
+      setState(() {
+        final index = _reminders.indexWhere((r) => r.id == updated.id);
+        if (index != -1) {
+          _reminders[index] = updated;
+        }
+      });
+      await _notifyParent();
+    } catch (e) {
+      showErrorBanner('Не удалось обновить напоминание');
+    }
+  }
+
+  Future<void> _deleteReminder(Reminder reminder) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: Text(reminder.title),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && reminder.id != null) {
+      try {
+        await _db.deleteReminder(reminder.id!);
+        await ReminderScheduler.instance.cancelReminder(reminder.id!);
+        if (!mounted) return;
+        setState(() => _reminders.removeWhere((r) => r.id == reminder.id));
+        await _notifyParent();
+        showSuccessBanner('Напоминание удалено');
+      } catch (e) {
+        showErrorBanner('Не удалось удалить напоминание');
+      }
+    }
+  }
+
+  Widget _sectionHeader(String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(4, 16, 4, 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+
+  Widget _reminderTile(Reminder reminder) {
+    final theme = Theme.of(context);
+    final dateText = DateFormat('dd.MM.yyyy HH:mm').format(reminder.remindAt);
+    final isCompleted = reminder.isCompleted;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        leading: Checkbox(
+          value: isCompleted,
+          onChanged: (_) => _toggleCompleted(reminder),
+        ),
+        title: Text(
+          reminder.title,
+          style: theme.textTheme.bodyLarge?.copyWith(
+            decoration: isCompleted ? TextDecoration.lineThrough : null,
+            color: isCompleted ? theme.hintColor : null,
+          ),
+        ),
+        subtitle: Text(dateText),
+        trailing: PopupMenuButton<String>(
+          onSelected: (value) {
+            switch (value) {
+              case 'edit':
+                _editReminder(reminder);
+                break;
+              case 'delete':
+                _deleteReminder(reminder);
+                break;
+            }
+          },
+          itemBuilder: (context) => [
+            const PopupMenuItem(
+              value: 'edit',
+              child: ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: Icon(Icons.edit),
+                title: Text('Редактировать'),
+              ),
+            ),
+            const PopupMenuItem(
+              value: 'delete',
+              child: ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: Icon(Icons.delete_outline),
+                title: Text('Удалить'),
+              ),
+            ),
+          ],
+        ),
+        onTap: () => _toggleCompleted(reminder),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final upcoming = _reminders
+        .where((r) => !r.isCompleted)
+        .toList()
+      ..sort((a, b) => a.remindAt.compareTo(b.remindAt));
+    final completed = _reminders
+        .where((r) => r.isCompleted)
+        .toList()
+      ..sort((a, b) => b.remindAt.compareTo(a.remindAt));
+
+    final showEmpty = !_isLoading && upcoming.isEmpty && completed.isEmpty;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Напоминания'),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _addReminder,
+        icon: const Icon(Icons.add_alarm),
+        label: const Text('Новое напоминание'),
+      ),
+      body: SafeArea(
+        child: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Padding(
+                padding: const EdgeInsets.all(16),
+                child: showEmpty
+                    ? Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: const [
+                            Icon(Icons.alarm_off, size: 48),
+                            SizedBox(height: 12),
+                            Text('Напоминаний пока нет'),
+                          ],
+                        ),
+                      )
+                    : ListView(
+                        children: [
+                          if (upcoming.isNotEmpty) ...[
+                            _sectionHeader('Активные'),
+                            ...upcoming.map(_reminderTile),
+                          ],
+                          if (completed.isNotEmpty) ...[
+                            if (upcoming.isNotEmpty) const SizedBox(height: 8),
+                            _sectionHeader('Выполненные'),
+                            ...completed.map(_reminderTile),
+                          ],
+                        ],
+                      ),
+              ),
+      ),
+    );
+  }
+}

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart' as p;
 import 'package:flutter/foundation.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
 
 class ContactDatabase {
   ContactDatabase._();
@@ -22,8 +23,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 2, чтобы сработала миграция с FK + CASCADE
-      version: 2,
+      // ВАЖНО: поднимаем версию до 3, чтобы сработала миграция с FK + CASCADE + напоминаниями
+      version: 3,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -65,6 +66,19 @@ class ContactDatabase {
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_category_createdAt ON contacts(category, createdAt)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(name)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
+        await db.execute('''
+          CREATE TABLE reminders(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contactId INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            remindAt INTEGER NOT NULL,
+            isCompleted INTEGER NOT NULL DEFAULT 0,
+            createdAt INTEGER NOT NULL,
+            FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+          )
+        ''');
+        await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
+        await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_completed ON reminders(isCompleted, remindAt)');
       },
 
       onUpgrade: (db, oldV, newV) async {
@@ -101,6 +115,22 @@ class ContactDatabase {
           await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
 
           await db.execute('PRAGMA foreign_keys = ON'); // включаем обратно
+        }
+
+        if (oldV < 3) {
+          await db.execute('''
+            CREATE TABLE IF NOT EXISTS reminders(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              contactId INTEGER NOT NULL,
+              title TEXT NOT NULL,
+              remindAt INTEGER NOT NULL,
+              isCompleted INTEGER NOT NULL DEFAULT 0,
+              createdAt INTEGER NOT NULL,
+              FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+            )
+          ''');
+          await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
+          await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_completed ON reminders(isCompleted, remindAt)');
         }
       },
     );
@@ -260,31 +290,121 @@ class ContactDatabase {
     return maps.map(Note.fromMap).toList();
   }
 
+  // ================= Reminders =================
+
+  Future<int> insertReminder(Reminder reminder) async {
+    final db = await database;
+    final id = await db.insert('reminders', _mapForInsert(reminder.toMap()));
+    _bumpRevision();
+    return id;
+  }
+
+  Future<int> updateReminder(Reminder reminder) async {
+    final db = await database;
+    final rows = await db.update(
+      'reminders',
+      reminder.toMap(),
+      where: 'id = ?',
+      whereArgs: [reminder.id],
+    );
+    _bumpRevision();
+    return rows;
+  }
+
+  Future<int> deleteReminder(int id) async {
+    final db = await database;
+    final rows = await db.delete('reminders', where: 'id = ?', whereArgs: [id]);
+    _bumpRevision();
+    return rows;
+  }
+
+  Future<List<Reminder>> remindersByContact(int contactId) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'remindAt ASC',
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
+  Future<List<Reminder>> remindersByContactPaged(
+    int contactId, {
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'remindAt ASC',
+      limit: limit,
+      offset: offset,
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
+  Future<List<Reminder>> upcomingRemindersByContact(
+    int contactId, {
+    int limit = 3,
+    bool includeCompleted = false,
+  }) async {
+    final db = await database;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final whereBuffer = StringBuffer('contactId = ?');
+    final whereArgs = <Object?>[contactId];
+    if (!includeCompleted) {
+      whereBuffer.write(' AND isCompleted = 0');
+    }
+    whereBuffer.write(' AND remindAt >= ?');
+    whereArgs.add(now);
+
+    final maps = await db.query(
+      'reminders',
+      where: whereBuffer.toString(),
+      whereArgs: whereArgs,
+      orderBy: 'remindAt ASC',
+      limit: limit,
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
   // ================= Helpers для Undo =================
 
-  /// Удаляет контакт (каскадно удаляются заметки) и возвращает снапшот заметок.
-  /// В UI можно сохранить возвращённый список для последующего Undo.
+  /// Удаляет контакт (каскадно удаляются заметки и напоминания) и возвращает
+  /// их снимок. В UI можно сохранить возвращённые списки для последующего Undo.
   ///
   /// Операция обёрнута в транзакцию, чтобы снимок и удаление были атомарными.
-  Future<List<Note>> deleteContactWithSnapshot(int contactId) async {
+  Future<ContactCascadeSnapshot> deleteContactWithSnapshot(int contactId) async {
     final db = await database;
-    final snapshot = <Note>[];
+    final notesSnapshot = <Note>[];
+    final remindersSnapshot = <Reminder>[];
 
     await db.transaction((txn) async {
-      final maps = await txn.query(
+      final noteMaps = await txn.query(
         'notes',
         where: 'contactId = ?',
         whereArgs: [contactId],
         orderBy: 'createdAt DESC',
       );
-      snapshot.addAll(maps.map(Note.fromMap));
+      notesSnapshot.addAll(noteMaps.map(Note.fromMap));
 
-      // Удаляем контакт — FK каскадно удалит связанные заметки
+      final reminderMaps = await txn.query(
+        'reminders',
+        where: 'contactId = ?',
+        whereArgs: [contactId],
+        orderBy: 'remindAt ASC',
+      );
+      remindersSnapshot.addAll(reminderMaps.map(Reminder.fromMap));
+
+      // Удаляем контакт — FK каскадно удалит связанные заметки и напоминания
       await txn.delete('contacts', where: 'id = ?', whereArgs: [contactId]);
     });
 
     _bumpRevision();
-    return snapshot;
+    return ContactCascadeSnapshot(notes: notesSnapshot, reminders: remindersSnapshot);
   }
 
   /// Восстанавливает контакт (получает НОВЫЙ id) и возвращает его.
@@ -295,9 +415,13 @@ class ContactDatabase {
     return newId;
   }
 
-  /// Восстанавливает контакт и ВСЕ его заметки за одну транзакцию.
+  /// Восстанавливает контакт и все его заметки/напоминания за одну транзакцию.
   /// Возвращает новый id контакта.
-  Future<int> restoreContactWithNotes(Contact contact, List<Note> notes) async {
+  Future<int> restoreContactWithNotes(
+    Contact contact,
+    List<Note> notes, {
+    List<Reminder> reminders = const [],
+  }) async {
     final db = await database;
     int newContactId = 0;
 
@@ -310,9 +434,26 @@ class ContactDatabase {
         final noteMap = _mapForInsert(n.copyWith(contactId: newContactId, id: null).toMap());
         await txn.insert('notes', noteMap);
       }
+
+      for (final r in reminders) {
+        final reminderMap = _mapForInsert(
+          r.copyWith(contactId: newContactId, id: null).toMap(),
+        );
+        await txn.insert('reminders', reminderMap);
+      }
     });
 
     _bumpRevision();
     return newContactId;
   }
+}
+
+class ContactCascadeSnapshot {
+  final List<Note> notes;
+  final List<Reminder> reminders;
+
+  const ContactCascadeSnapshot({
+    this.notes = const [],
+    this.reminders = const [],
+  });
 }

--- a/lib/services/reminder_scheduler.dart
+++ b/lib/services/reminder_scheduler.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import '../models/reminder.dart';
+
+class ReminderScheduler {
+  ReminderScheduler._();
+
+  static final ReminderScheduler instance = ReminderScheduler._();
+
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+  bool _initialized = false;
+
+  static const String _channelId = 'contact_reminders';
+  static const String _channelName = 'Напоминания о контактах';
+  static const String _channelDescription = 'Напоминания, связанные с контактами';
+
+  Future<void> ensureInitialized() async {
+    if (_initialized) return;
+    if (kIsWeb) {
+      _initialized = true;
+      return;
+    }
+
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+    const settings = InitializationSettings(android: androidSettings, iOS: iosSettings);
+
+    try {
+      await _plugin.initialize(settings);
+    } catch (e, stack) {
+      debugPrint('ReminderScheduler initialization error: $e\n$stack');
+    }
+
+    if (!kIsWeb && defaultTargetPlatform == TargetPlatform.iOS) {
+      await _plugin
+          .resolvePlatformSpecificImplementation<DarwinFlutterLocalNotificationsPlugin>()
+          ?.requestPermissions(alert: true, badge: true, sound: true);
+    } else if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+      final androidPlugin =
+          _plugin.resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+      await androidPlugin?.requestNotificationsPermission();
+      await androidPlugin?.requestExactAlarmsPermission();
+    }
+
+    _initialized = true;
+  }
+
+  NotificationDetails _notificationDetails() {
+    return const NotificationDetails(
+      android: AndroidNotificationDetails(
+        _channelId,
+        _channelName,
+        channelDescription: _channelDescription,
+        importance: Importance.max,
+        priority: Priority.high,
+        visibility: NotificationVisibility.public,
+      ),
+      iOS: DarwinNotificationDetails(
+        presentAlert: true,
+        presentBadge: true,
+        presentSound: true,
+      ),
+    );
+  }
+
+  Future<void> scheduleReminder(Reminder reminder, {String? contactName}) async {
+    if (kIsWeb) return;
+    final id = reminder.id;
+    if (id == null) return;
+
+    await ensureInitialized();
+
+    await _cancel(id);
+
+    if (reminder.isCompleted) return;
+    if (!reminder.remindAt.isAfter(DateTime.now())) return;
+
+    final trimmedName = contactName?.trim();
+    final title = (trimmedName != null && trimmedName.isNotEmpty)
+        ? 'Напоминание: $trimmedName'
+        : 'Напоминание о контакте';
+
+    try {
+      await _plugin.schedule(
+        id,
+        title,
+        reminder.title,
+        reminder.remindAt,
+        _notificationDetails(),
+        androidAllowWhileIdle: true,
+      );
+    } catch (e, stack) {
+      debugPrint('Failed to schedule reminder#$id: $e\n$stack');
+    }
+  }
+
+  Future<void> scheduleMany(Iterable<Reminder> reminders, {String? contactName}) async {
+    for (final reminder in reminders) {
+      await scheduleReminder(reminder, contactName: contactName);
+    }
+  }
+
+  Future<void> cancelReminder(int id) async {
+    if (kIsWeb) return;
+    await ensureInitialized();
+    await _cancel(id);
+  }
+
+  Future<void> cancelMany(Iterable<int> ids) async {
+    if (kIsWeb) return;
+    await ensureInitialized();
+    for (final id in ids) {
+      await _cancel(id);
+    }
+  }
+
+  Future<void> _cancel(int id) async {
+    try {
+      await _plugin.cancel(id);
+    } catch (e, stack) {
+      debugPrint('Failed to cancel reminder#$id: $e\n$stack');
+    }
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
   overlay_support: ^2.1.0
+  flutter_local_notifications: ^17.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a reminder scheduler service that initializes flutter_local_notifications and manages schedule/cancel flows
- hook reminder CRUD and contact undo flows to register or cancel notifications as needed
- initialize the scheduler at startup and declare the flutter_local_notifications dependency

## Testing
- not run (flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d46c424d8483289138ff0e5f5849cf