### PR TITLE
Implement contact reminders with local notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="touchnotebookbeta_flutter"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,9 +41,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>CADisableMinimumFrameDurationOnPhone</key>
+        <true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSUserNotificationUsageDescription</key>
+        <string>Напоминания помогают не забыть связаться с контактами.</string>
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 import 'app.dart';
+import 'services/reminder_database_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await ReminderDatabaseService.instance.initialize();
   runApp(const App());
 }
 

--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -1,0 +1,42 @@
+class Reminder {
+  final int? id;
+  final int contactId;
+  final String title;
+  final DateTime scheduledDateTime;
+
+  const Reminder({
+    this.id,
+    required this.contactId,
+    required this.title,
+    required this.scheduledDateTime,
+  });
+
+  Reminder copyWith({
+    int? id,
+    int? contactId,
+    String? title,
+    DateTime? scheduledDateTime,
+  }) {
+    return Reminder(
+      id: id ?? this.id,
+      contactId: contactId ?? this.contactId,
+      title: title ?? this.title,
+      scheduledDateTime: scheduledDateTime ?? this.scheduledDateTime,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'contactId': contactId,
+        'title': title,
+        'scheduledDateTime': scheduledDateTime.millisecondsSinceEpoch,
+      };
+
+  factory Reminder.fromMap(Map<String, dynamic> map) => Reminder(
+        id: map['id'] as int?,
+        contactId: map['contactId'] as int,
+        title: map['title'] as String,
+        scheduledDateTime:
+            DateTime.fromMillisecondsSinceEpoch(map['scheduledDateTime'] as int),
+      );
+}

--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -18,7 +18,7 @@ abstract class Dict {
     'Потенциальный': ['Холодный', 'Тёплый', 'Потерянный'],
   };
 
-  static const tags = ['Новый', 'Напомнить', 'VIP'];
+  static const tags = ['Новый', 'VIP'];
 }
 
 class AddContactScreen extends StatefulWidget {

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -9,10 +9,12 @@ import 'package:overlay_support/overlay_support.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
 import '../services/contact_database.dart';
+import '../services/reminder_database_service.dart';
 import '../widgets/system_notifications.dart';
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
 import 'contact_list_screen.dart';
+import 'reminder_list_screen.dart';
 
 class ContactDetailsScreen extends StatefulWidget {
   final Contact contact;
@@ -1071,8 +1073,10 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     if (c.id == null) return;
 
     final db = ContactDatabase.instance;
+    final reminderService = ReminderDatabaseService.instance;
 
     // Удаляем контакт и забираем снапшот заметок для возможного Undo
+    await reminderService.deleteRemindersForContact(c.id!);
     final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
 
     // Показываем баннер с Undo
@@ -1513,7 +1517,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     spacing: 8,
                     runSpacing: 8,
                     children: [
-                      for (final label in const ['Новый', 'Напомнить', 'VIP'])
+                      for (final label in const ['Новый', 'VIP'])
                         ChoiceChip(
                           label: Text(label),
                           selected: _tags.contains(label),
@@ -1623,6 +1627,21 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     if (v) _scrollToCard(_notesCardKey);
                   },
                   headerActions: [
+                    TextButton(
+                      onPressed: _contact.id == null
+                          ? null
+                          : () async {
+                        await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ReminderListScreen(
+                              contact: _contact,
+                            ),
+                          ),
+                        );
+                      },
+                      child: const Text('Напоминания'),
+                    ),
                     TextButton(
                       onPressed: _contact.id == null
                           ? null

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:overlay_support/overlay_support.dart';
 import '../app.dart'; // для App.navigatorKey
 import '../models/contact.dart';
 import '../services/contact_database.dart';
+import '../services/reminder_database_service.dart';
 import '../widgets/system_notifications.dart';
 import 'add_contact_screen.dart';
 import 'contact_details_screen.dart';
@@ -488,8 +489,10 @@ class _ContactListScreenState extends State<ContactListScreen> {
   Future<void> _deleteWithUndo(Contact c) async {
     if (c.id == null) return;
     final db = ContactDatabase.instance;
+    final reminderService = ReminderDatabaseService.instance;
     try {
       // 1) Снимок заметок + удаление контакта (каскад снесёт заметки)
+      await reminderService.deleteRemindersForContact(c.id!);
       final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
       // 2) Убираем из локального списка
       setState(() {

--- a/lib/screens/reminder_list_screen.dart
+++ b/lib/screens/reminder_list_screen.dart
@@ -1,0 +1,364 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/contact.dart';
+import '../models/reminder.dart';
+import '../services/reminder_database_service.dart';
+import '../widgets/system_notifications.dart';
+
+class ReminderListScreen extends StatefulWidget {
+  final Contact contact;
+
+  const ReminderListScreen({super.key, required this.contact});
+
+  @override
+  State<ReminderListScreen> createState() => _ReminderListScreenState();
+}
+
+class _ReminderListScreenState extends State<ReminderListScreen> {
+  final _service = ReminderDatabaseService.instance;
+
+  List<Reminder> _reminders = const [];
+  bool _isLoading = false;
+  bool _fetchInProgress = false;
+
+  late final VoidCallback _revisionListener;
+
+  @override
+  void initState() {
+    super.initState();
+    _revisionListener = () => _loadReminders(silent: true);
+    _service.revision.addListener(_revisionListener);
+    _loadReminders();
+  }
+
+  @override
+  void dispose() {
+    _service.revision.removeListener(_revisionListener);
+    super.dispose();
+  }
+
+  Future<void> _loadReminders({bool silent = false}) async {
+    if (widget.contact.id == null) return;
+    if (_fetchInProgress) return;
+    _fetchInProgress = true;
+    if (!silent && mounted) {
+      setState(() => _isLoading = true);
+    }
+
+    try {
+      final reminders = await _service.remindersByContact(widget.contact.id!);
+      if (!mounted) return;
+      setState(() {
+        _reminders = reminders;
+      });
+    } catch (_) {
+      if (mounted) {
+        showErrorBanner('Не удалось загрузить напоминания');
+      }
+    } finally {
+      _fetchInProgress = false;
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _addReminder() async {
+    if (widget.contact.id == null) return;
+    final created = await _openReminderEditor();
+    if (created == null) return;
+
+    try {
+      await _service.insertReminder(created);
+      if (!mounted) return;
+      showSuccessBanner('Напоминание создано');
+      await _loadReminders(silent: true);
+    } catch (_) {
+      if (mounted) {
+        showErrorBanner('Не удалось сохранить напоминание');
+      }
+    }
+  }
+
+  Future<void> _editReminder(Reminder reminder) async {
+    final edited = await _openReminderEditor(reminder: reminder);
+    if (edited == null) return;
+
+    try {
+      await _service.updateReminder(edited);
+      if (!mounted) return;
+      showSuccessBanner('Напоминание обновлено');
+      await _loadReminders(silent: true);
+    } catch (_) {
+      if (mounted) {
+        showErrorBanner('Не удалось обновить напоминание');
+      }
+    }
+  }
+
+  Future<void> _deleteReminder(Reminder reminder) async {
+    if (reminder.id == null) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: const Text('Это действие нельзя отменить.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      await _service.deleteReminder(reminder.id!);
+      if (!mounted) return;
+      showSuccessBanner('Напоминание удалено');
+      await _loadReminders(silent: true);
+    } catch (_) {
+      if (mounted) {
+        showErrorBanner('Не удалось удалить напоминание');
+      }
+    }
+  }
+
+  Future<Reminder?> _openReminderEditor({Reminder? reminder}) async {
+    if (widget.contact.id == null) return null;
+
+    final controller = TextEditingController(text: reminder?.title ?? '');
+    DateTime scheduled = reminder?.scheduledDateTime ??
+        DateTime.now().add(const Duration(hours: 1));
+    bool showTitleError = false;
+
+    final result = await showDialog<Reminder>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            Future<void> pickDate() async {
+              final pickedDate = await showDatePicker(
+                context: context,
+                initialDate: scheduled,
+                firstDate: DateTime(2000),
+                lastDate: DateTime(2100),
+              );
+              if (pickedDate != null) {
+                scheduled = DateTime(
+                  pickedDate.year,
+                  pickedDate.month,
+                  pickedDate.day,
+                  scheduled.hour,
+                  scheduled.minute,
+                );
+                setState(() {});
+              }
+            }
+
+            Future<void> pickTime() async {
+              final pickedTime = await showTimePicker(
+                context: context,
+                initialTime: TimeOfDay.fromDateTime(scheduled),
+              );
+              if (pickedTime != null) {
+                scheduled = DateTime(
+                  scheduled.year,
+                  scheduled.month,
+                  scheduled.day,
+                  pickedTime.hour,
+                  pickedTime.minute,
+                );
+                setState(() {});
+              }
+            }
+
+            final formattedDate = DateFormat('dd.MM.yyyy').format(scheduled);
+            final formattedTime = DateFormat('HH:mm').format(scheduled);
+
+            return AlertDialog(
+              title: Text(reminder == null ? 'Новое напоминание' : 'Редактирование'),
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    TextField(
+                      controller: controller,
+                      decoration: InputDecoration(
+                        labelText: 'Текст напоминания',
+                        errorText: showTitleError ? 'Введите текст' : null,
+                      ),
+                      autofocus: true,
+                      onChanged: (value) {
+                        if (showTitleError && value.trim().isNotEmpty) {
+                          setState(() => showTitleError = false);
+                        }
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    Text('Дата', style: Theme.of(context).textTheme.titleSmall),
+                    const SizedBox(height: 8),
+                    FilledButton.tonal(
+                      onPressed: pickDate,
+                      child: Text(formattedDate),
+                    ),
+                    const SizedBox(height: 16),
+                    Text('Время', style: Theme.of(context).textTheme.titleSmall),
+                    const SizedBox(height: 8),
+                    FilledButton.tonal(
+                      onPressed: pickTime,
+                      child: Text(formattedTime),
+                    ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Отмена'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    final title = controller.text.trim();
+                    if (title.isEmpty) {
+                      setState(() => showTitleError = true);
+                      return;
+                    }
+                    Navigator.pop(
+                      context,
+                      Reminder(
+                        id: reminder?.id,
+                        contactId: widget.contact.id!,
+                        title: title,
+                        scheduledDateTime: scheduled,
+                      ),
+                    );
+                  },
+                  child: const Text('Сохранить'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    controller.dispose();
+    return result;
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    final date = DateFormat('dd MMMM yyyy', 'ru').format(dateTime);
+    final time = DateFormat('HH:mm').format(dateTime);
+    return '$date в $time';
+  }
+
+  Widget _buildPlaceholder({required Widget child}) {
+    return RefreshIndicator(
+      onRefresh: () => _loadReminders(silent: true),
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.all(32),
+        children: [
+          Center(child: child),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildList() {
+    return RefreshIndicator(
+      onRefresh: () => _loadReminders(silent: true),
+      child: ListView.separated(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _reminders.length,
+        itemBuilder: (context, index) {
+          final reminder = _reminders[index];
+          return ListTile(
+            leading: const Icon(Icons.alarm),
+            title: Text(reminder.title),
+            subtitle: Text(_formatDateTime(reminder.scheduledDateTime)),
+            trailing: Wrap(
+              spacing: 8,
+              children: [
+                IconButton(
+                  tooltip: 'Редактировать',
+                  icon: const Icon(Icons.edit_outlined),
+                  onPressed: () => _editReminder(reminder),
+                ),
+                IconButton(
+                  tooltip: 'Удалить',
+                  icon: const Icon(Icons.delete_outline),
+                  onPressed: () => _deleteReminder(reminder),
+                ),
+              ],
+            ),
+          );
+        },
+        separatorBuilder: (context, index) => const Divider(height: 1),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasContactId = widget.contact.id != null;
+
+    Widget body;
+    if (!hasContactId) {
+      body = _buildPlaceholder(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.info_outline, size: 48),
+            SizedBox(height: 16),
+            Text(
+              'Сохраните контакт, чтобы добавлять напоминания',
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+    } else if (_isLoading && _reminders.isEmpty) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (_reminders.isEmpty) {
+      body = _buildPlaceholder(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.alarm_add_outlined, size: 48),
+            SizedBox(height: 16),
+            Text(
+              'Напоминаний пока нет',
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+    } else {
+      body = _buildList();
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Напоминания'),
+      ),
+      body: SafeArea(child: body),
+      floatingActionButton: hasContactId
+          ? FloatingActionButton.extended(
+              onPressed: _addReminder,
+              icon: const Icon(Icons.add),
+              label: const Text('Добавить'),
+            )
+          : null,
+    );
+  }
+}

--- a/lib/services/reminder_database_service.dart
+++ b/lib/services/reminder_database_service.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+import '../models/reminder.dart';
+import 'contact_database.dart';
+
+class ReminderDatabaseService {
+  ReminderDatabaseService._();
+  static final ReminderDatabaseService instance = ReminderDatabaseService._();
+
+  final FlutterLocalNotificationsPlugin _notificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  bool _initialized = false;
+
+  final ValueNotifier<int> revision = ValueNotifier<int>(0);
+  void _bumpRevision() => revision.value++;
+
+  static const AndroidNotificationDetails _androidDetails =
+      AndroidNotificationDetails(
+    'contact_reminders',
+    'Напоминания контактов',
+    channelDescription: 'Уведомления о напоминаниях для контактов',
+    importance: Importance.max,
+    priority: Priority.high,
+  );
+
+  static const DarwinNotificationDetails _darwinDetails =
+      DarwinNotificationDetails(
+    presentAlert: true,
+    presentBadge: true,
+    presentSound: true,
+  );
+
+  static const NotificationDetails _notificationDetails = NotificationDetails(
+    android: _androidDetails,
+    iOS: _darwinDetails,
+    macOS: _darwinDetails,
+  );
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+
+    tz.initializeTimeZones();
+    try {
+      final timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
+      tz.setLocalLocation(tz.getLocation(timeZoneName));
+    } catch (_) {
+      tz.setLocalLocation(tz.UTC);
+    }
+
+    const initializationSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      iOS: DarwinInitializationSettings(),
+      macOS: DarwinInitializationSettings(),
+    );
+
+    await _notificationsPlugin.initialize(initializationSettings);
+
+    await _notificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.requestNotificationsPermission();
+    await _notificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(alert: true, badge: true, sound: true);
+
+    await _notificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            MacOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(alert: true, badge: true, sound: true);
+
+    await _rescheduleAllReminders();
+
+    _initialized = true;
+  }
+
+  Future<void> _ensureInitialized() async {
+    if (!_initialized) {
+      await initialize();
+    }
+  }
+
+  Future<List<Reminder>> remindersByContact(int contactId) async {
+    await _ensureInitialized();
+    final db = await ContactDatabase.instance.database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'scheduledDateTime ASC',
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
+  Future<Reminder> insertReminder(Reminder reminder) async {
+    await _ensureInitialized();
+    final db = await ContactDatabase.instance.database;
+    final id = await db.insert(
+      'reminders',
+      _mapForInsert(reminder.toMap()),
+    );
+    final inserted = reminder.copyWith(id: id);
+    await _scheduleReminder(inserted);
+    _bumpRevision();
+    return inserted;
+  }
+
+  Future<Reminder> updateReminder(Reminder reminder) async {
+    if (reminder.id == null) {
+      throw ArgumentError('Reminder id is required for update');
+    }
+    await _ensureInitialized();
+    final db = await ContactDatabase.instance.database;
+    await db.update(
+      'reminders',
+      reminder.toMap(),
+      where: 'id = ?',
+      whereArgs: [reminder.id],
+    );
+    await _notificationsPlugin.cancel(reminder.id!);
+    await _scheduleReminder(reminder);
+    _bumpRevision();
+    return reminder;
+  }
+
+  Future<void> deleteReminder(int id) async {
+    await _ensureInitialized();
+    final db = await ContactDatabase.instance.database;
+    await _notificationsPlugin.cancel(id);
+    await db.delete('reminders', where: 'id = ?', whereArgs: [id]);
+    _bumpRevision();
+  }
+
+  Future<void> deleteRemindersForContact(int contactId) async {
+    await _ensureInitialized();
+    final db = await ContactDatabase.instance.database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      columns: ['id'],
+    );
+    final ids = maps.map((m) => m['id'] as int).toList();
+    for (final id in ids) {
+      await _notificationsPlugin.cancel(id);
+    }
+    await db.delete('reminders', where: 'contactId = ?', whereArgs: [contactId]);
+    if (ids.isNotEmpty) {
+      _bumpRevision();
+    }
+  }
+
+  Future<void> _rescheduleAllReminders() async {
+    await _notificationsPlugin.cancelAll();
+    final db = await ContactDatabase.instance.database;
+    final maps = await db.query('reminders');
+    final reminders = maps.map(Reminder.fromMap).toList();
+    for (final reminder in reminders) {
+      await _scheduleReminder(reminder);
+    }
+  }
+
+  Future<void> _scheduleReminder(Reminder reminder) async {
+    if (reminder.id == null) return;
+
+    var scheduled = tz.TZDateTime.from(reminder.scheduledDateTime, tz.local);
+    final now = tz.TZDateTime.now(tz.local);
+    if (!scheduled.isAfter(now)) {
+      scheduled = now.add(const Duration(seconds: 1));
+    }
+
+    final contactName = await _contactName(reminder.contactId);
+    final body = contactName == null ? null : 'Контакт: $contactName';
+
+    await _notificationsPlugin.zonedSchedule(
+      reminder.id!,
+      reminder.title,
+      body,
+      scheduled,
+      _notificationDetails,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      payload: reminder.contactId.toString(),
+    );
+  }
+
+  Map<String, Object?> _mapForInsert(Map<String, Object?> src) {
+    final map = Map<String, Object?>.from(src);
+    map.remove('id');
+    return map;
+  }
+
+  Future<String?> _contactName(int contactId) async {
+    final db = await ContactDatabase.instance.database;
+    final result = await db.query(
+      'contacts',
+      where: 'id = ?',
+      whereArgs: [contactId],
+      limit: 1,
+      columns: ['name'],
+    );
+    if (result.isEmpty) return null;
+    return result.first['name'] as String?;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,9 @@ dependencies:
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
   overlay_support: ^2.1.0
+  flutter_local_notifications: ^17.1.2
+  timezone: ^0.9.4
+  flutter_native_timezone: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a Reminder model, schema migrations, and a reminder database service that schedules local notifications
- introduce ReminderListScreen with create/edit/delete flows and hook it into contact details while removing the legacy “Напомнить” tag option
- initialize reminders on app start and request platform permissions, including Android/iOS manifest updates and new dependencies

## Testing
- not run (flutter toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d662993e3883288ac102a720ce7ffd