### PR TITLE
Use DateTime-based scheduling for reminders

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 
 import 'app.dart';
+import 'services/contact_database.dart';
+import 'services/reminder_notifications.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await ReminderNotifications.instance.init();
+  await ContactDatabase.instance.reschedulePendingReminders();
   runApp(const App());
 }
 

--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -1,0 +1,59 @@
+class Reminder {
+  final int? id;
+  final int contactId;
+  final String text;
+  final DateTime scheduledAt;
+  final DateTime createdAt;
+
+  const Reminder({
+    this.id,
+    required this.contactId,
+    required this.text,
+    required this.scheduledAt,
+    required this.createdAt,
+  });
+
+  Reminder copyWith({
+    int? id,
+    int? contactId,
+    String? text,
+    DateTime? scheduledAt,
+    DateTime? createdAt,
+  }) {
+    return Reminder(
+      id: id ?? this.id,
+      contactId: contactId ?? this.contactId,
+      text: text ?? this.text,
+      scheduledAt: scheduledAt ?? this.scheduledAt,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'contactId': contactId,
+        'text': text,
+        'scheduledAt': scheduledAt.millisecondsSinceEpoch,
+        'createdAt': createdAt.millisecondsSinceEpoch,
+      };
+
+  factory Reminder.fromMap(Map<String, dynamic> map) {
+    return Reminder(
+      id: map['id'] as int?,
+      contactId: map['contactId'] as int,
+      text: map['text'] as String,
+      scheduledAt: DateTime.fromMillisecondsSinceEpoch(map['scheduledAt'] as int),
+      createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+    );
+  }
+}
+
+class ReminderScheduleInfo {
+  final Reminder reminder;
+  final String contactName;
+
+  const ReminderScheduleInfo({
+    required this.reminder,
+    required this.contactName,
+  });
+}

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -8,11 +8,14 @@ import 'package:overlay_support/overlay_support.dart';
 
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
 import '../services/contact_database.dart';
 import '../widgets/system_notifications.dart';
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
 import 'contact_list_screen.dart';
+import 'reminder_form_screen.dart';
+import 'reminders_list_screen.dart';
 
 class ContactDetailsScreen extends StatefulWidget {
   final Contact contact;
@@ -51,6 +54,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   // --- keys для автоскролла к самим карточкам ---
   final _extraCardKey = GlobalKey();
+  final _remindersCardKey = GlobalKey();
   final _notesCardKey = GlobalKey();
 
   IconData _statusIcon(String s) {
@@ -85,6 +89,35 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
         ],
       ),
       onTap: null,
+      isLast: isLast,
+    );
+  }
+
+  Widget _reminderRow(Reminder reminder, {bool isLast = false}) {
+    final theme = Theme.of(context);
+    final isPast = reminder.scheduledAt.isBefore(DateTime.now());
+    final icon = isPast ? Icons.history : Icons.alarm_outlined;
+    final color = isPast ? theme.colorScheme.outline : theme.colorScheme.primary;
+
+    return _sheetRow(
+      leading: Icon(icon, color: color),
+      right: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            reminder.text,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodyLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            DateFormat('dd.MM.yyyy HH:mm').format(reminder.scheduledAt),
+            style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+          ),
+        ],
+      ),
+      onTap: _contact.id == null ? null : () => _editReminder(reminder),
       isLast: isLast,
     );
   }
@@ -503,7 +536,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   bool _addedOpen = false;
 
   bool _extraExpanded = false; // «Дополнительно»
+  bool _remindersExpanded = true;
   bool _notesExpanded = true; // «Заметки» открыто
+  List<Reminder> _reminders = [];
   List<Note> _notes = [];
 
   // FocusNodes — для подсветки/навигации
@@ -548,6 +583,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     super.initState();
     _contact = widget.contact;
     _loadFromContact();
+    _loadReminders();
     _loadNotes();
     // чтобы превью обновлялось при каждом символе
     _phoneController.addListener(() => setState(() {}));
@@ -584,6 +620,60 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     if (_contact.id == null) return;
     final notes = await ContactDatabase.instance.lastNotesByContact(_contact.id!, limit: 3);
     if (mounted) setState(() => _notes = notes);
+  }
+
+  Future<void> _loadReminders() async {
+    if (_contact.id == null) return;
+    final reminders = await ContactDatabase.instance.upcomingRemindersByContact(_contact.id!, limit: 3);
+    if (mounted) setState(() => _reminders = reminders);
+  }
+
+  Future<void> _addReminder() async {
+    if (_contact.id == null) return;
+    final reminder = await Navigator.push<Reminder>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ReminderFormScreen(
+          contactId: _contact.id!,
+          contactName: _contact.name,
+        ),
+      ),
+    );
+    if (reminder != null) {
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание добавлено');
+    }
+  }
+
+  Future<void> _editReminder(Reminder reminder) async {
+    if (_contact.id == null) return;
+    final updated = await Navigator.push<Reminder>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ReminderFormScreen(
+          contactId: _contact.id!,
+          contactName: _contact.name,
+          reminder: reminder,
+        ),
+      ),
+    );
+    if (updated != null) {
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Изменения сохранены');
+    }
+  }
+
+  Future<void> _openRemindersList() async {
+    if (_contact.id == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => RemindersListScreen(contact: _contact),
+      ),
+    );
+    await _loadReminders();
   }
 
   Future<void> _addNote() async {
@@ -1052,6 +1142,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
     final updated = _snapshot();
     await ContactDatabase.instance.update(updated);
+    if (updated.id != null) {
+      await ContactDatabase.instance.rescheduleRemindersForContact(updated.id!);
+    }
     if (!mounted) return;
 
     // Обновляем локальный снапшот (без setState — мы всё равно уходим со страницы)
@@ -1531,6 +1624,74 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     ],
                   ),
                 ],
+              ),
+
+              // ===== Блок: Напоминания =====
+              KeyedSubtree(
+                key: _remindersCardKey,
+                child: _collapsibleSectionCard(
+                  title: 'Напоминания',
+                  expanded: _remindersExpanded,
+                  onChanged: (v) {
+                    setState(() => _remindersExpanded = v);
+                    if (v) _scrollToCard(_remindersCardKey);
+                  },
+                  headerActions: [
+                    if (_contact.id != null)
+                      OutlinedButton(
+                        onPressed: _openRemindersList,
+                        child: const Text('Все напоминания'),
+                      ),
+                    if (_contact.id != null) const SizedBox(width: 8),
+                    if (_contact.id != null)
+                      FilledButton.icon(
+                        onPressed: _addReminder,
+                        icon: const Icon(Icons.add_alarm_outlined),
+                        label: const Text('Добавить'),
+                      ),
+                  ],
+                  children: _reminders.isEmpty
+                      ? [
+                          Card(
+                            elevation: 0,
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(
+                                    Icons.alarm_off_outlined,
+                                    size: 48,
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Text(
+                                    'Нет напоминаний',
+                                    style: Theme.of(context).textTheme.titleMedium,
+                                    textAlign: TextAlign.center,
+                                  ),
+                                  const SizedBox(height: 24),
+                                  FilledButton.icon(
+                                    onPressed: _contact.id == null ? null : _addReminder,
+                                    icon: const Icon(Icons.add),
+                                    label: const Text('Добавить напоминание'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ]
+                      : [
+                          Card(
+                            elevation: 0,
+                            child: Column(
+                              children: [
+                                for (var i = 0; i < _reminders.length; i++)
+                                  _reminderRow(_reminders[i], isLast: i == _reminders.length - 1),
+                              ],
+                            ),
+                          ),
+                        ],
+                ),
               ),
 
               // ===== Блок: Дополнительно =====

--- a/lib/screens/reminder_form_screen.dart
+++ b/lib/screens/reminder_form_screen.dart
@@ -1,0 +1,262 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+
+class ReminderFormScreen extends StatefulWidget {
+  final int contactId;
+  final String contactName;
+  final Reminder? reminder;
+
+  const ReminderFormScreen({
+    super.key,
+    required this.contactId,
+    required this.contactName,
+    this.reminder,
+  });
+
+  bool get isEditing => reminder != null;
+
+  @override
+  State<ReminderFormScreen> createState() => _ReminderFormScreenState();
+}
+
+class _ReminderFormScreenState extends State<ReminderFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _textController;
+  late DateTime _scheduledAt;
+
+  @override
+  void initState() {
+    super.initState();
+    final initialReminder = widget.reminder;
+    _textController = TextEditingController(text: initialReminder?.text ?? '');
+    _scheduledAt = initialReminder?.scheduledAt ?? DateTime.now().add(const Duration(hours: 1));
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  InputDecoration _fieldDecoration({required String label, IconData? icon}) {
+    final theme = Theme.of(context);
+    return InputDecoration(
+      labelText: label,
+      prefixIcon: icon != null ? Icon(icon) : null,
+      border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: theme.dividerColor),
+      ),
+      isDense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+    );
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _scheduledAt,
+      firstDate: DateTime.now().subtract(const Duration(days: 3650)),
+      lastDate: DateTime.now().add(const Duration(days: 3650)),
+      locale: const Locale('ru'),
+    );
+    if (picked != null) {
+      setState(() {
+        _scheduledAt = DateTime(
+          picked.year,
+          picked.month,
+          picked.day,
+          _scheduledAt.hour,
+          _scheduledAt.minute,
+        );
+      });
+    }
+  }
+
+  Future<void> _pickTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(_scheduledAt),
+    );
+    if (picked != null) {
+      setState(() {
+        _scheduledAt = DateTime(
+          _scheduledAt.year,
+          _scheduledAt.month,
+          _scheduledAt.day,
+          picked.hour,
+          picked.minute,
+        );
+      });
+    }
+  }
+
+  bool get _canSave => (_formKey.currentState?.validate() ?? false) && _textController.text.trim().isNotEmpty;
+
+  Future<void> _save() async {
+    if (!_canSave) return;
+
+    final trimmed = _textController.text.trim();
+    final now = DateTime.now();
+
+    final reminder = (widget.reminder ?? Reminder(
+          contactId: widget.contactId,
+          text: trimmed,
+          scheduledAt: _scheduledAt,
+          createdAt: now,
+        ))
+        .copyWith(
+          text: trimmed,
+          scheduledAt: _scheduledAt,
+        );
+
+    if (reminder.id == null) {
+      final id = await ContactDatabase.instance.insertReminder(
+        reminder,
+        contactName: widget.contactName,
+      );
+      if (!mounted) return;
+      Navigator.pop(context, reminder.copyWith(id: id));
+    } else {
+      await ContactDatabase.instance.updateReminder(
+        reminder,
+        contactName: widget.contactName,
+      );
+      if (!mounted) return;
+      Navigator.pop(context, reminder);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateText = DateFormat('dd.MM.yyyy').format(_scheduledAt);
+    final timeText = DateFormat('HH:mm').format(_scheduledAt);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          tooltip: 'Отмена',
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text(widget.isEditing ? 'Редактировать напоминание' : 'Новое напоминание'),
+        actions: [
+          if (_canSave)
+            IconButton(
+              tooltip: 'Сохранить',
+              icon: const Icon(Icons.check),
+              onPressed: _save,
+            )
+          else
+            const SizedBox.shrink(),
+        ],
+      ),
+      body: SafeArea(
+        child: GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          behavior: HitTestBehavior.opaque,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              child: ListView(
+                children: [
+                  Card(
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    clipBehavior: Clip.antiAlias,
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Текст напоминания',
+                            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            controller: _textController,
+                            maxLines: null,
+                            textInputAction: TextInputAction.newline,
+                            decoration: _fieldDecoration(label: 'Напоминание*', icon: Icons.alarm_outlined),
+                            onChanged: (_) => setState(() {}),
+                            validator: (value) => (value == null || value.trim().isEmpty) ? 'Введите текст напоминания' : null,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Card(
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    clipBehavior: Clip.antiAlias,
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Когда напомнить',
+                            style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                          const SizedBox(height: 12),
+                          Material(
+                            color: Colors.transparent,
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                            clipBehavior: Clip.antiAlias,
+                            child: InkWell(
+                              onTap: _pickDate,
+                              child: ListTile(
+                                leading: const Icon(Icons.event_outlined),
+                                title: const Text('Дата'),
+                                subtitle: Text(dateText),
+                                trailing: const Icon(Icons.arrow_drop_down),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Material(
+                            color: Colors.transparent,
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                            clipBehavior: Clip.antiAlias,
+                            child: InkWell(
+                              onTap: _pickTime,
+                              child: ListTile(
+                                leading: const Icon(Icons.schedule_outlined),
+                                title: const Text('Время'),
+                                subtitle: Text(timeText),
+                                trailing: const Icon(Icons.arrow_drop_down),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: _canSave
+            ? FilledButton.icon(
+                onPressed: _save,
+                icon: const Icon(Icons.check),
+                label: Text(widget.isEditing ? 'Сохранить' : 'Создать'),
+                style: FilledButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 14)),
+              )
+            : const SizedBox.shrink(),
+      ),
+    );
+  }
+}

--- a/lib/screens/reminders_list_screen.dart
+++ b/lib/screens/reminders_list_screen.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/contact.dart';
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+import '../widgets/system_notifications.dart';
+import 'reminder_form_screen.dart';
+
+class RemindersListScreen extends StatefulWidget {
+  final Contact contact;
+
+  const RemindersListScreen({super.key, required this.contact});
+
+  @override
+  State<RemindersListScreen> createState() => _RemindersListScreenState();
+}
+
+class _RemindersListScreenState extends State<RemindersListScreen> {
+  final ContactDatabase _db = ContactDatabase.instance;
+  List<Reminder> _reminders = [];
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadReminders();
+    _db.revision.addListener(_onDbRevision);
+  }
+
+  @override
+  void dispose() {
+    _db.revision.removeListener(_onDbRevision);
+    super.dispose();
+  }
+
+  void _onDbRevision() {
+    if (!mounted) return;
+    _loadReminders();
+  }
+
+  Future<void> _loadReminders() async {
+    if (widget.contact.id == null) return;
+    setState(() => _isLoading = true);
+    final list = await _db.remindersByContact(widget.contact.id!);
+    if (!mounted) return;
+    setState(() {
+      _reminders = list;
+      _isLoading = false;
+    });
+  }
+
+  Future<void> _addReminder() async {
+    final contactId = widget.contact.id;
+    if (contactId == null) return;
+    final result = await Navigator.push<Reminder>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ReminderFormScreen(
+          contactId: contactId,
+          contactName: widget.contact.name,
+        ),
+      ),
+    );
+    if (result != null && mounted) {
+      await _loadReminders();
+      showSuccessBanner('Напоминание добавлено');
+    }
+  }
+
+  Future<void> _editReminder(Reminder reminder) async {
+    final contactId = widget.contact.id;
+    if (contactId == null) return;
+    final updated = await Navigator.push<Reminder>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ReminderFormScreen(
+          contactId: contactId,
+          contactName: widget.contact.name,
+          reminder: reminder,
+        ),
+      ),
+    );
+    if (updated != null && mounted) {
+      await _loadReminders();
+      showSuccessBanner('Изменения сохранены');
+    }
+  }
+
+  Future<bool> _confirmDelete(Reminder reminder) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: const Text('Напоминание также будет удалено из расписания уведомлений.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    return confirmed ?? false;
+  }
+
+  Future<void> _deleteReminder(Reminder reminder) async {
+    if (reminder.id == null) return;
+    await _db.deleteReminder(reminder.id!);
+    if (!mounted) return;
+    setState(() {
+      _reminders.removeWhere((r) => r.id == reminder.id);
+    });
+    showSuccessBanner('Напоминание удалено');
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_reminders.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.alarm_off_outlined, size: 64, color: Theme.of(context).colorScheme.outline),
+              const SizedBox(height: 16),
+              Text(
+                'Пока нет напоминаний',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 12),
+              const Text('Добавьте напоминание, чтобы не забыть о важном событии.'),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _loadReminders,
+      child: ListView.builder(
+        padding: const EdgeInsets.only(bottom: 96),
+        itemCount: _reminders.length,
+        itemBuilder: (context, index) {
+          final reminder = _reminders[index];
+          return _ReminderTile(
+            reminder: reminder,
+            onTap: () => _editReminder(reminder),
+            onDelete: () => _deleteReminder(reminder),
+            confirmDelete: () => _confirmDelete(reminder),
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Напоминания'),
+      ),
+      body: SafeArea(child: _buildBody()),
+      floatingActionButton: widget.contact.id == null
+          ? null
+          : FloatingActionButton(
+              onPressed: _addReminder,
+              child: const Icon(Icons.add),
+            ),
+    );
+  }
+}
+
+class _ReminderTile extends StatelessWidget {
+  final Reminder reminder;
+  final VoidCallback onTap;
+  final Future<void> Function() onDelete;
+  final Future<bool> Function() confirmDelete;
+
+  const _ReminderTile({
+    required this.reminder,
+    required this.onTap,
+    required this.onDelete,
+    required this.confirmDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isPast = reminder.scheduledAt.isBefore(DateTime.now());
+    final icon = isPast ? Icons.history : Icons.alarm;
+    final color = isPast ? theme.colorScheme.outline : theme.colorScheme.primary;
+    final date = DateFormat('dd.MM.yyyy HH:mm').format(reminder.scheduledAt);
+
+    return Dismissible(
+      key: ValueKey(reminder.id ?? reminder.hashCode),
+      direction: DismissDirection.endToStart,
+      confirmDismiss: (_) => confirmDelete(),
+      onDismissed: (_) => onDelete(),
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.errorContainer,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Icon(Icons.delete_outline, color: theme.colorScheme.onErrorContainer),
+      ),
+      child: Card(
+        margin: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        child: ListTile(
+          onTap: onTap,
+          leading: Icon(icon, color: color),
+          title: Text(reminder.text),
+          subtitle: Text(date),
+          trailing: const Icon(Icons.chevron_right),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -4,6 +4,8 @@ import 'package:path/path.dart' as p;
 import 'package:flutter/foundation.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
+import 'reminder_notifications.dart';
 
 class ContactDatabase {
   ContactDatabase._();
@@ -22,8 +24,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 2, чтобы сработала миграция с FK + CASCADE
-      version: 2,
+      // ВАЖНО: поднимаем версию до 3, чтобы сработали миграции с FK и напоминаниями
+      version: 3,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -65,6 +67,17 @@ class ContactDatabase {
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_category_createdAt ON contacts(category, createdAt)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(name)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
+        await db.execute('''
+          CREATE TABLE reminders(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contactId INTEGER NOT NULL,
+            text TEXT NOT NULL,
+            scheduledAt INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL,
+            FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+          )
+        ''');
+        await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_scheduledAt ON reminders(contactId, scheduledAt)');
       },
 
       onUpgrade: (db, oldV, newV) async {
@@ -101,6 +114,20 @@ class ContactDatabase {
           await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
 
           await db.execute('PRAGMA foreign_keys = ON'); // включаем обратно
+        }
+
+        if (oldV < 3) {
+          await db.execute('''
+            CREATE TABLE IF NOT EXISTS reminders(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              contactId INTEGER NOT NULL,
+              text TEXT NOT NULL,
+              scheduledAt INTEGER NOT NULL,
+              createdAt INTEGER NOT NULL,
+              FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+            )
+          ''');
+          await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_scheduledAt ON reminders(contactId, scheduledAt)');
         }
       },
     );
@@ -178,6 +205,7 @@ class ContactDatabase {
 
   Future<int> delete(int id) async {
     final db = await database;
+    await cancelRemindersForContact(id);
     final rows = await db.delete('contacts', where: 'id = ?', whereArgs: [id]);
     _bumpRevision();
     return rows;
@@ -260,6 +288,133 @@ class ContactDatabase {
     return maps.map(Note.fromMap).toList();
   }
 
+  // ================= Reminders =================
+
+  Future<List<Reminder>> remindersByContact(int contactId) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'scheduledAt ASC',
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
+  Future<List<Reminder>> upcomingRemindersByContact(int contactId, {int limit = 3}) async {
+    final db = await database;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ? AND scheduledAt >= ?',
+      whereArgs: [contactId, now - const Duration(minutes: 1).inMilliseconds],
+      orderBy: 'scheduledAt ASC',
+      limit: limit,
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
+  Future<int> insertReminder(Reminder reminder, {required String contactName}) async {
+    final db = await database;
+    final id = await db.insert('reminders', _mapForInsert(reminder.toMap()));
+    final stored = reminder.copyWith(id: id);
+    await ReminderNotifications.instance.scheduleReminder(stored, contactName: contactName);
+    _bumpRevision();
+    return id;
+  }
+
+  Future<int> updateReminder(Reminder reminder, {required String contactName}) async {
+    if (reminder.id == null) return 0;
+    final db = await database;
+    final rows = await db.update(
+      'reminders',
+      reminder.toMap(),
+      where: 'id = ?',
+      whereArgs: [reminder.id],
+    );
+    if (rows > 0) {
+      await ReminderNotifications.instance.scheduleReminder(reminder, contactName: contactName);
+      _bumpRevision();
+    }
+    return rows;
+  }
+
+  Future<int> deleteReminder(int id) async {
+    final db = await database;
+    final rows = await db.delete('reminders', where: 'id = ?', whereArgs: [id]);
+    if (rows > 0) {
+      await ReminderNotifications.instance.cancelReminder(id);
+      _bumpRevision();
+    }
+    return rows;
+  }
+
+  Future<void> cancelRemindersForContact(int contactId) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      columns: ['id'],
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+    );
+    final ids = maps.map((e) => e['id']).whereType<int>();
+    await ReminderNotifications.instance.cancelReminders(ids);
+  }
+
+  Future<List<ReminderScheduleInfo>> _reminderScheduleEntries({int? contactId}) async {
+    final db = await database;
+    final args = <Object?>[];
+    final buffer = StringBuffer();
+    if (contactId != null) {
+      buffer.write('WHERE r.contactId = ?');
+      args.add(contactId);
+    } else {
+      buffer.write('WHERE r.scheduledAt >= ?');
+      args.add(DateTime.now().subtract(const Duration(minutes: 1)).millisecondsSinceEpoch);
+    }
+
+    final rows = await db.rawQuery('''
+      SELECT
+        r.id as id,
+        r.contactId as contactId,
+        r.text as text,
+        r.scheduledAt as scheduledAt,
+        r.createdAt as createdAt,
+        c.name as contactName
+      FROM reminders r
+      JOIN contacts c ON c.id = r.contactId
+      ${buffer.toString()}
+      ORDER BY r.scheduledAt ASC
+    ''', args);
+
+    return rows
+        .map((row) => ReminderScheduleInfo(
+              reminder: Reminder.fromMap(row),
+              contactName: row['contactName'] as String,
+            ))
+        .toList();
+  }
+
+  Future<void> reschedulePendingReminders() async {
+    final entries = await _reminderScheduleEntries();
+    for (final entry in entries) {
+      await ReminderNotifications.instance.scheduleReminder(
+        entry.reminder,
+        contactName: entry.contactName,
+      );
+    }
+  }
+
+  Future<void> rescheduleRemindersForContact(int contactId) async {
+    final entries = await _reminderScheduleEntries(contactId: contactId);
+    for (final entry in entries) {
+      await ReminderNotifications.instance.scheduleReminder(
+        entry.reminder,
+        contactName: entry.contactName,
+      );
+    }
+  }
+
   // ================= Helpers для Undo =================
 
   /// Удаляет контакт (каскадно удаляются заметки) и возвращает снапшот заметок.
@@ -269,6 +424,7 @@ class ContactDatabase {
   Future<List<Note>> deleteContactWithSnapshot(int contactId) async {
     final db = await database;
     final snapshot = <Note>[];
+    final reminderIds = <int>[];
 
     await db.transaction((txn) async {
       final maps = await txn.query(
@@ -279,9 +435,21 @@ class ContactDatabase {
       );
       snapshot.addAll(maps.map(Note.fromMap));
 
+      final reminders = await txn.query(
+        'reminders',
+        columns: ['id'],
+        where: 'contactId = ?',
+        whereArgs: [contactId],
+      );
+      reminderIds.addAll(reminders.map((e) => e['id']).whereType<int>());
+
       // Удаляем контакт — FK каскадно удалит связанные заметки
       await txn.delete('contacts', where: 'id = ?', whereArgs: [contactId]);
     });
+
+    if (reminderIds.isNotEmpty) {
+      await ReminderNotifications.instance.cancelReminders(reminderIds);
+    }
 
     _bumpRevision();
     return snapshot;

--- a/lib/services/reminder_notifications.dart
+++ b/lib/services/reminder_notifications.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import '../models/reminder.dart';
+
+class ReminderNotifications {
+  ReminderNotifications._();
+
+  static final ReminderNotifications instance = ReminderNotifications._();
+
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+  bool _initialized = false;
+
+  Future<void> init() async {
+    if (_initialized) return;
+
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosInit = DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+
+    const initSettings = InitializationSettings(
+      android: androidInit,
+      iOS: iosInit,
+      macOS: iosInit,
+    );
+
+    await _plugin.initialize(initSettings);
+
+    final androidPlugin = _plugin.resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+    await androidPlugin?.requestNotificationsPermission();
+    await androidPlugin?.requestExactAlarmsPermission();
+
+    final iosPlugin = _plugin.resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>();
+    await iosPlugin?.requestPermissions(alert: true, badge: true, sound: true);
+
+    _initialized = true;
+  }
+
+  Future<void> scheduleReminder(Reminder reminder, {required String contactName}) async {
+    await init();
+    if (reminder.id == null) return;
+
+    final now = DateTime.now();
+    if (reminder.scheduledAt.isBefore(now.subtract(const Duration(minutes: 1)))) {
+      await cancelReminder(reminder.id!);
+      return;
+    }
+
+    final scheduleDate = reminder.scheduledAt.toLocal();
+
+    const androidDetails = AndroidNotificationDetails(
+      'contact_reminders',
+      'Напоминания по контактам',
+      channelDescription: 'Локальные напоминания для контактов',
+      importance: Importance.max,
+      priority: Priority.high,
+    );
+
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    final notificationDetails = const NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+      macOS: iosDetails,
+    );
+
+    await _plugin.schedule(
+      reminder.id!,
+      contactName,
+      reminder.text,
+      scheduleDate,
+      notificationDetails,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      payload: reminder.contactId.toString(),
+    );
+  }
+
+  Future<void> cancelReminder(int reminderId) async {
+    await init();
+    await _plugin.cancel(reminderId);
+  }
+
+  Future<void> cancelReminders(Iterable<int> reminderIds) async {
+    await init();
+    for (final id in reminderIds) {
+      await _plugin.cancel(id);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
   overlay_support: ^2.1.0
+  flutter_local_notifications: ^17.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- drop timezone dependencies and rely on the platform local DateTime for reminder scheduling
- update reminder notification helper to schedule alarms without querying flutter_timezone

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d669f2ac6483289cda3526e93a87d0