### PR TITLE
Add reminders support with UI and persistence

### DIFF
--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -1,0 +1,41 @@
+class Reminder {
+  final int? id;
+  final int contactId;
+  final DateTime dueAt;
+  final String? text;
+
+  const Reminder({
+    this.id,
+    required this.contactId,
+    required this.dueAt,
+    this.text,
+  });
+
+  Reminder copyWith({
+    int? id,
+    int? contactId,
+    DateTime? dueAt,
+    String? text,
+  }) {
+    return Reminder(
+      id: id ?? this.id,
+      contactId: contactId ?? this.contactId,
+      dueAt: dueAt ?? this.dueAt,
+      text: text ?? this.text,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'contactId': contactId,
+        'dueAt': dueAt.millisecondsSinceEpoch,
+        'text': text,
+      };
+
+  factory Reminder.fromMap(Map<String, dynamic> map) => Reminder(
+        id: map['id'] as int?,
+        contactId: map['contactId'] as int,
+        dueAt: DateTime.fromMillisecondsSinceEpoch(map['dueAt'] as int),
+        text: map['text'] as String?,
+      );
+}

--- a/lib/screens/add_reminder_screen.dart
+++ b/lib/screens/add_reminder_screen.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+
+class AddReminderScreen extends StatefulWidget {
+  final int contactId;
+  const AddReminderScreen({super.key, required this.contactId});
+
+  @override
+  State<AddReminderScreen> createState() => _AddReminderScreenState();
+}
+
+class _AddReminderScreenState extends State<AddReminderScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _textController = TextEditingController();
+  DateTime _dueAt = DateTime.now().add(const Duration(hours: 1));
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  InputDecoration _inputDec({
+    required String label,
+    String? hint,
+    IconData? prefixIcon,
+  }) {
+    final theme = Theme.of(context);
+    return InputDecoration(
+      labelText: label,
+      hintText: hint,
+      prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
+      border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide(color: theme.dividerColor),
+      ),
+      isDense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+    );
+  }
+
+  Widget _section({required String title, required List<Widget> children}) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      margin: const EdgeInsets.only(bottom: 16),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
+            const SizedBox(height: 12),
+            ...children,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _borderedTile({required Widget child}) {
+    final theme = Theme.of(context);
+    return Material(
+      color: Colors.transparent,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      clipBehavior: Clip.antiAlias,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: theme.dividerColor),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: child,
+      ),
+    );
+  }
+
+  Future<void> _pickDateTime() async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: _dueAt,
+      firstDate: DateTime.now().subtract(const Duration(days: 1)),
+      lastDate: DateTime(2100),
+      locale: const Locale('ru'),
+    );
+    if (date == null) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(_dueAt),
+    );
+    if (time == null) return;
+
+    setState(() {
+      _dueAt = DateTime(date.year, date.month, date.day, time.hour, time.minute);
+    });
+  }
+
+  bool get _canSave => true;
+
+  Future<void> _save() async {
+    final reminder = Reminder(
+      contactId: widget.contactId,
+      dueAt: _dueAt,
+      text: _textController.text.trim().isEmpty ? null : _textController.text.trim(),
+    );
+    final id = await ContactDatabase.instance.insertReminder(reminder);
+    if (!mounted) return;
+    Navigator.pop(context, reminder.copyWith(id: id));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dueStr = DateFormat('dd.MM.yyyy HH:mm').format(_dueAt);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          tooltip: 'Отмена',
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text('Добавить напоминание'),
+        actions: [
+          IconButton(
+            tooltip: 'Сохранить',
+            icon: const Icon(Icons.check),
+            onPressed: _save,
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          behavior: HitTestBehavior.opaque,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              child: ListView(
+                children: [
+                  _section(
+                    title: 'Описание',
+                    children: [
+                      TextFormField(
+                        controller: _textController,
+                        minLines: 1,
+                        maxLines: null,
+                        textInputAction: TextInputAction.newline,
+                        decoration: _inputDec(
+                          label: 'Текст',
+                          hint: 'Необязательное описание',
+                          prefixIcon: Icons.alarm,
+                        ),
+                      ),
+                    ],
+                  ),
+                  _section(
+                    title: 'Дата и время',
+                    children: [
+                      _borderedTile(
+                        child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                          leading: const Icon(Icons.event_available_outlined),
+                          title: const Text('Напомнить'),
+                          subtitle: Text(dueStr),
+                          trailing: const Icon(Icons.arrow_drop_down),
+                          onTap: _pickDateTime,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: FilledButton.icon(
+          onPressed: _save,
+          icon: const Icon(Icons.check),
+          label: const Text('Сохранить'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -490,7 +490,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
     final db = ContactDatabase.instance;
     try {
       // 1) Снимок заметок + удаление контакта (каскад снесёт заметки)
-      final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
+      final snapshot = await db.deleteContactWithSnapshot(c.id!);
       // 2) Убираем из локального списка
       setState(() {
         _all.removeWhere((e) => e.id == c.id);
@@ -504,8 +504,10 @@ class _ContactListScreenState extends State<ContactListScreen> {
         icon: Icons.delete_outline,
         onUndo: () async {
           _undoBanner = null;
-          final newId =
-              await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+          final newId = await db.restoreContactWithRelations(
+            c.copyWith(id: null),
+            snapshot,
+          );
           _restoreLocally(c.copyWith(id: newId), highlight: true);
         },
       );

--- a/lib/screens/reminder_details_screen.dart
+++ b/lib/screens/reminder_details_screen.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+
+class ReminderDetailsScreen extends StatefulWidget {
+  final Reminder reminder;
+
+  const ReminderDetailsScreen({super.key, required this.reminder});
+
+  @override
+  State<ReminderDetailsScreen> createState() => _ReminderDetailsScreenState();
+}
+
+class _ReminderDetailsScreenState extends State<ReminderDetailsScreen> {
+  late Reminder _reminder;
+  late Reminder _savedSnapshot;
+
+  final _formKey = GlobalKey<FormState>();
+  final _textController = TextEditingController();
+  DateTime _dueAt = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    _reminder = widget.reminder;
+    _loadFromReminder();
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  void _loadFromReminder() {
+    _textController.text = _reminder.text ?? '';
+    _dueAt = _reminder.dueAt;
+    _savedSnapshot = _reminder;
+    setState(() {});
+  }
+
+  bool get _isDirty {
+    final textChanged = _textController.text.trim() != (_savedSnapshot.text ?? '');
+    final dateChanged = !_dueAt.isAtSameMomentAs(_savedSnapshot.dueAt);
+    return textChanged || dateChanged;
+  }
+
+  Future<void> _pickDateTime() async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: _dueAt,
+      firstDate: DateTime.now().subtract(const Duration(days: 1)),
+      lastDate: DateTime(2100),
+      locale: const Locale('ru'),
+    );
+    if (date == null) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(_dueAt),
+    );
+    if (time == null) return;
+
+    setState(() {
+      _dueAt = DateTime(date.year, date.month, date.day, time.hour, time.minute);
+    });
+  }
+
+  Future<void> _save() async {
+    if (!_isDirty) return;
+
+    final updated = _reminder.copyWith(
+      dueAt: _dueAt,
+      text: _textController.text.trim().isEmpty ? null : _textController.text.trim(),
+    );
+
+    await ContactDatabase.instance.updateReminder(updated);
+    _reminder = updated;
+    _savedSnapshot = updated;
+
+    if (!mounted) return;
+    Navigator.pop(context, {'updated': updated});
+  }
+
+  Future<void> _delete() async {
+    if (_reminder.id == null) return;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: const Text('Это действие нельзя отменить.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+
+    if (ok != true) return;
+
+    await ContactDatabase.instance.deleteReminder(_reminder.id!);
+    if (!mounted) return;
+    Navigator.pop(context, {'deleted': _reminder});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dueStr = DateFormat('dd.MM.yyyy HH:mm').format(_dueAt);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          tooltip: _isDirty ? 'Отменить изменения' : 'Назад',
+          icon: Icon(_isDirty ? Icons.close : Icons.arrow_back),
+          onPressed: () {
+            if (_isDirty) {
+              _loadFromReminder();
+            } else {
+              Navigator.pop(context);
+            }
+          },
+        ),
+        title: const Text('Напоминание'),
+        actions: [
+          if (_isDirty)
+            IconButton(
+              tooltip: 'Сохранить',
+              icon: const Icon(Icons.check),
+              onPressed: _save,
+            ),
+        ],
+      ),
+      body: SafeArea(
+        child: GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          behavior: HitTestBehavior.opaque,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: ListView(
+                physics: const BouncingScrollPhysics(),
+                children: [
+                  Card(
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    margin: const EdgeInsets.only(bottom: 16),
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Описание',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            controller: _textController,
+                            minLines: 1,
+                            maxLines: null,
+                            textInputAction: TextInputAction.newline,
+                            decoration: InputDecoration(
+                              labelText: 'Текст',
+                              hintText: 'Необязательное описание',
+                              prefixIcon: const Icon(Icons.alarm),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                            onChanged: (_) => setState(() {}),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Card(
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    margin: const EdgeInsets.only(bottom: 16),
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Дата и время',
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleMedium
+                                ?.copyWith(fontWeight: FontWeight.w700),
+                          ),
+                          const SizedBox(height: 12),
+                          ListTile(
+                            contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                            leading: const Icon(Icons.event_available_outlined),
+                            title: const Text('Напомнить'),
+                            subtitle: Text(dueStr),
+                            trailing: const Icon(Icons.arrow_drop_down),
+                            onTap: _pickDateTime,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              side: BorderSide(color: Theme.of(context).dividerColor),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                      foregroundColor: Colors.white,
+                    ),
+                    onPressed: _delete,
+                    child: const Text('Удалить напоминание'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/reminders_list_screen.dart
+++ b/lib/screens/reminders_list_screen.dart
@@ -1,0 +1,299 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/contact.dart';
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+import 'add_reminder_screen.dart';
+import 'reminder_details_screen.dart';
+
+class RemindersListScreen extends StatefulWidget {
+  final Contact contact;
+  final ValueChanged<Reminder>? onReminderChanged;
+
+  const RemindersListScreen({super.key, required this.contact, this.onReminderChanged});
+
+  @override
+  State<RemindersListScreen> createState() => _RemindersListScreenState();
+}
+
+enum SortRemindersOption { dueAsc, dueDesc }
+
+class _RemindersListScreenState extends State<RemindersListScreen> {
+  final _db = ContactDatabase.instance;
+  final ScrollController _scroll = ScrollController();
+
+  List<Reminder> _reminders = [];
+  List<Reminder> _sortedReminders = [];
+
+  static const int _pageSize = 20;
+  int _page = 0;
+  bool _isLoading = false;
+  bool _hasMore = true;
+  bool _initialLoaded = false;
+
+  SortRemindersOption _sort = SortRemindersOption.dueAsc;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadReminders(reset: true);
+    _scroll.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scroll.removeListener(_onScroll);
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadReminders({bool reset = false}) async {
+    if (reset) {
+      _page = 0;
+      _hasMore = true;
+      _reminders = [];
+      _sortedReminders = [];
+    }
+    await _loadMoreReminders(reset: reset);
+  }
+
+  void _onScroll() {
+    if (_scroll.position.pixels >= _scroll.position.maxScrollExtent - 200) {
+      _loadMoreReminders();
+    }
+  }
+
+  Future<void> _loadMoreReminders({bool reset = false}) async {
+    if (widget.contact.id == null || _isLoading) return;
+    if (!reset && !_hasMore) return;
+
+    setState(() => _isLoading = true);
+
+    List<Reminder> pageReminders = [];
+    try {
+      pageReminders = await _db.remindersByContactPaged(
+        widget.contact.id!,
+        limit: _pageSize,
+        offset: _page * _pageSize,
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Не удалось загрузить напоминания: $e')),
+        );
+      }
+    }
+
+    if (!mounted) return;
+
+    setState(() {
+      if (reset) {
+        _reminders = [...pageReminders];
+        _page = 1;
+        _hasMore = pageReminders.length >= _pageSize;
+      } else {
+        final existingIds = _reminders.map((e) => e.id).toSet();
+        final unique = pageReminders.where((n) => !existingIds.contains(n.id)).toList();
+        _reminders.addAll(unique);
+        _page++;
+        if (pageReminders.length < _pageSize) _hasMore = false;
+      }
+      _isLoading = false;
+      _initialLoaded = true;
+      _rebuildSorted();
+    });
+  }
+
+  void _rebuildSorted() {
+    final list = [..._reminders];
+    switch (_sort) {
+      case SortRemindersOption.dueAsc:
+        list.sort((a, b) => a.dueAt.compareTo(b.dueAt));
+        break;
+      case SortRemindersOption.dueDesc:
+        list.sort((a, b) => b.dueAt.compareTo(a.dueAt));
+        break;
+    }
+    _sortedReminders = list;
+  }
+
+  Future<void> _openSort() async {
+    final result = await showModalBottomSheet<SortRemindersOption>(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RadioListTile<SortRemindersOption>(
+                title: const Text('Сначала ближайшие'),
+                value: SortRemindersOption.dueAsc,
+                groupValue: _sort,
+                onChanged: (v) => Navigator.pop(context, v),
+              ),
+              RadioListTile<SortRemindersOption>(
+                title: const Text('Сначала поздние'),
+                value: SortRemindersOption.dueDesc,
+                groupValue: _sort,
+                onChanged: (v) => Navigator.pop(context, v),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    if (result != null && result != _sort) {
+      setState(() {
+        _sort = result;
+        _rebuildSorted();
+      });
+    }
+  }
+
+  Future<void> _onAddReminder() async {
+    if (widget.contact.id == null) return;
+    final reminder = await Navigator.push<Reminder>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => AddReminderScreen(contactId: widget.contact.id!),
+      ),
+    );
+    if (reminder != null) {
+      setState(() {
+        _reminders.add(reminder);
+        _rebuildSorted();
+      });
+      widget.onReminderChanged?.call(reminder);
+    }
+  }
+
+  Future<void> _openReminder(Reminder reminder) async {
+    if (reminder.id == null) return;
+    final result = await Navigator.push<Map<String, dynamic>?>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ReminderDetailsScreen(reminder: reminder),
+      ),
+    );
+    if (result == null) return;
+
+    if (result['deleted'] is Reminder) {
+      setState(() {
+        _reminders.removeWhere((r) => r.id == reminder.id);
+        _rebuildSorted();
+      });
+      widget.onReminderChanged?.call(reminder);
+    } else if (result['updated'] is Reminder) {
+      final updated = result['updated'] as Reminder;
+      final index = _reminders.indexWhere((r) => r.id == updated.id);
+      if (index >= 0) {
+        setState(() {
+          _reminders[index] = updated;
+          _rebuildSorted();
+        });
+      }
+      widget.onReminderChanged?.call(updated);
+    }
+  }
+
+  Future<void> _deleteReminder(Reminder reminder) async {
+    if (reminder.id == null) return;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: const Text('Это действие нельзя отменить.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+
+    await ContactDatabase.instance.deleteReminder(reminder.id!);
+    if (!mounted) return;
+
+    setState(() {
+      _reminders.removeWhere((r) => r.id == reminder.id);
+      _rebuildSorted();
+    });
+    widget.onReminderChanged?.call(reminder);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final df = DateFormat('dd.MM.yyyy HH:mm');
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Напоминания'),
+        actions: [
+          IconButton(
+            tooltip: 'Сортировка',
+            icon: const Icon(Icons.sort),
+            onPressed: _openSort,
+          ),
+        ],
+      ),
+      floatingActionButton: widget.contact.id == null
+          ? null
+          : FloatingActionButton.extended(
+              onPressed: _onAddReminder,
+              icon: const Icon(Icons.add_alarm),
+              label: const Text('Напоминание'),
+            ),
+      body: RefreshIndicator(
+        onRefresh: () => _loadReminders(reset: true),
+        child: _initialLoaded && _sortedReminders.isEmpty
+            ? ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: const [
+                  SizedBox(height: 120),
+                  Center(child: Text('Напоминаний пока нет')),
+                  SizedBox(height: 120),
+                ],
+              )
+            : ListView.builder(
+                controller: _scroll,
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                itemCount: _sortedReminders.length + (_hasMore ? 1 : 0),
+                itemBuilder: (context, index) {
+                  if (index >= _sortedReminders.length) {
+                    return const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Center(child: CircularProgressIndicator()),
+                    );
+                  }
+                  final reminder = _sortedReminders[index];
+                  final title = (reminder.text ?? '').trim().isEmpty
+                      ? 'Без описания'
+                      : reminder.text!.trim();
+                  final due = df.format(reminder.dueAt);
+                  return Card(
+                    margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                    child: ListTile(
+                      leading: const Icon(Icons.alarm),
+                      title: Text(title),
+                      subtitle: Text(due),
+                      onTap: () => _openReminder(reminder),
+                      trailing: IconButton(
+                        tooltip: 'Удалить',
+                        icon: const Icon(Icons.delete_outline),
+                        onPressed: () => _deleteReminder(reminder),
+                      ),
+                    ),
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -4,6 +4,17 @@ import 'package:path/path.dart' as p;
 import 'package:flutter/foundation.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
+
+class ContactCascadeSnapshot {
+  final List<Note> notes;
+  final List<Reminder> reminders;
+
+  const ContactCascadeSnapshot({
+    this.notes = const [],
+    this.reminders = const [],
+  });
+}
 
 class ContactDatabase {
   ContactDatabase._();
@@ -22,8 +33,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 2, чтобы сработала миграция с FK + CASCADE
-      version: 2,
+      // ВАЖНО: поднимаем версию до 3, чтобы сработали миграции с FK + CASCADE и напоминаниями
+      version: 3,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -65,6 +76,16 @@ class ContactDatabase {
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_category_createdAt ON contacts(category, createdAt)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(name)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
+        await db.execute('''
+          CREATE TABLE reminders(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contactId INTEGER NOT NULL,
+            dueAt INTEGER NOT NULL,
+            text TEXT,
+            FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+          )
+        ''');
+        await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_dueAt ON reminders(contactId, dueAt)');
       },
 
       onUpgrade: (db, oldV, newV) async {
@@ -101,6 +122,18 @@ class ContactDatabase {
           await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
 
           await db.execute('PRAGMA foreign_keys = ON'); // включаем обратно
+        }
+        if (oldV < 3) {
+          await db.execute('''
+            CREATE TABLE IF NOT EXISTS reminders(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              contactId INTEGER NOT NULL,
+              dueAt INTEGER NOT NULL,
+              text TEXT,
+              FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+            )
+          ''');
+          await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_dueAt ON reminders(contactId, dueAt)');
         }
       },
     );
@@ -260,15 +293,85 @@ class ContactDatabase {
     return maps.map(Note.fromMap).toList();
   }
 
+  // ================= Reminders =================
+
+  Future<int> insertReminder(Reminder reminder) async {
+    final db = await database;
+    final id = await db.insert('reminders', _mapForInsert(reminder.toMap()));
+    _bumpRevision();
+    return id;
+  }
+
+  Future<int> updateReminder(Reminder reminder) async {
+    final db = await database;
+    final rows = await db.update(
+      'reminders',
+      reminder.toMap(),
+      where: 'id = ?',
+      whereArgs: [reminder.id],
+    );
+    _bumpRevision();
+    return rows;
+  }
+
+  Future<int> deleteReminder(int id) async {
+    final db = await database;
+    final rows = await db.delete('reminders', where: 'id = ?', whereArgs: [id]);
+    _bumpRevision();
+    return rows;
+  }
+
+  Future<List<Reminder>> remindersByContact(int contactId) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'dueAt ASC',
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
+  Future<List<Reminder>> remindersByContactPaged(
+    int contactId, {
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'dueAt ASC',
+      limit: limit,
+      offset: offset,
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
+  Future<List<Reminder>> upcomingReminders({int limit = 20, DateTime? from}) async {
+    final db = await database;
+    final now = from ?? DateTime.now();
+    final maps = await db.query(
+      'reminders',
+      where: 'dueAt >= ?',
+      whereArgs: [now.millisecondsSinceEpoch],
+      orderBy: 'dueAt ASC',
+      limit: limit,
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
   // ================= Helpers для Undo =================
 
   /// Удаляет контакт (каскадно удаляются заметки) и возвращает снапшот заметок.
   /// В UI можно сохранить возвращённый список для последующего Undo.
   ///
   /// Операция обёрнута в транзакцию, чтобы снимок и удаление были атомарными.
-  Future<List<Note>> deleteContactWithSnapshot(int contactId) async {
+  Future<ContactCascadeSnapshot> deleteContactWithSnapshot(int contactId) async {
     final db = await database;
-    final snapshot = <Note>[];
+    final notes = <Note>[];
+    final reminders = <Reminder>[];
 
     await db.transaction((txn) async {
       final maps = await txn.query(
@@ -277,14 +380,22 @@ class ContactDatabase {
         whereArgs: [contactId],
         orderBy: 'createdAt DESC',
       );
-      snapshot.addAll(maps.map(Note.fromMap));
+      notes.addAll(maps.map(Note.fromMap));
+
+      final reminderMaps = await txn.query(
+        'reminders',
+        where: 'contactId = ?',
+        whereArgs: [contactId],
+        orderBy: 'dueAt ASC',
+      );
+      reminders.addAll(reminderMaps.map(Reminder.fromMap));
 
       // Удаляем контакт — FK каскадно удалит связанные заметки
       await txn.delete('contacts', where: 'id = ?', whereArgs: [contactId]);
     });
 
     _bumpRevision();
-    return snapshot;
+    return ContactCascadeSnapshot(notes: notes, reminders: reminders);
   }
 
   /// Восстанавливает контакт (получает НОВЫЙ id) и возвращает его.
@@ -297,7 +408,10 @@ class ContactDatabase {
 
   /// Восстанавливает контакт и ВСЕ его заметки за одну транзакцию.
   /// Возвращает новый id контакта.
-  Future<int> restoreContactWithNotes(Contact contact, List<Note> notes) async {
+  Future<int> restoreContactWithRelations(
+    Contact contact,
+    ContactCascadeSnapshot snapshot,
+  ) async {
     final db = await database;
     int newContactId = 0;
 
@@ -306,9 +420,16 @@ class ContactDatabase {
       newContactId = await txn.insert('contacts', _mapForInsert(contact.toMap()));
 
       // Вставляем его заметки с новым contactId
-      for (final n in notes) {
+      for (final n in snapshot.notes) {
         final noteMap = _mapForInsert(n.copyWith(contactId: newContactId, id: null).toMap());
         await txn.insert('notes', noteMap);
+      }
+
+      // Вставляем его напоминания
+      for (final r in snapshot.reminders) {
+        final reminderMap =
+            _mapForInsert(r.copyWith(contactId: newContactId, id: null).toMap());
+        await txn.insert('reminders', reminderMap);
       }
     });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^5.0.0
   mocktail: ^1.0.1
+  sqflite_common_ffi: ^2.3.0+3
 
 flutter:
   uses-material-design: true

--- a/test/services/contact_database_test.dart
+++ b/test/services/contact_database_test.dart
@@ -1,0 +1,126 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:touchnotebookbeta_flutter/models/contact.dart';
+import 'package:touchnotebookbeta_flutter/models/note.dart';
+import 'package:touchnotebookbeta_flutter/models/reminder.dart';
+import 'package:touchnotebookbeta_flutter/services/contact_database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late ContactDatabase db;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('contact_db_test');
+    await databaseFactoryFfi.setDatabasesPath(tempDir.path);
+    db = ContactDatabase.instance;
+    await db.close(); // force reopen with new path
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Contact _sampleContact({String category = 'Клиент'}) => Contact(
+        name: 'Иван Иванов',
+        phone: '+7 (912) 000-00-00',
+        category: category,
+        status: 'Активный',
+        createdAt: DateTime.now(),
+        tags: const [],
+      );
+
+  test('reminder CRUD operations', () async {
+    final contactId = await db.insert(_sampleContact());
+
+    final reminder1 = Reminder(
+      contactId: contactId,
+      dueAt: DateTime.now().add(const Duration(days: 1)),
+      text: 'Позвонить',
+    );
+    final reminder2 = Reminder(
+      contactId: contactId,
+      dueAt: DateTime.now().add(const Duration(days: 2)),
+      text: 'Отправить письмо',
+    );
+
+    final id1 = await db.insertReminder(reminder1);
+    final id2 = await db.insertReminder(reminder2);
+
+    final byContact = await db.remindersByContact(contactId);
+    expect(byContact.length, 2);
+    expect(byContact.first.id, id1);
+    expect(byContact.last.id, id2);
+
+    final paged = await db.remindersByContactPaged(contactId, limit: 1, offset: 1);
+    expect(paged.length, 1);
+    expect(paged.first.id, id2);
+
+    final updatedText = 'Изменить план';
+    await db.updateReminder(reminder1.copyWith(id: id1, text: updatedText));
+    final afterUpdate = await db.remindersByContact(contactId);
+    expect(afterUpdate.firstWhere((r) => r.id == id1).text, updatedText);
+
+    final upcoming = await db.upcomingReminders(limit: 5);
+    expect(upcoming.map((r) => r.id), containsAll({id1, id2}));
+
+    await db.deleteReminder(id1);
+    final remaining = await db.remindersByContact(contactId);
+    expect(remaining.map((r) => r.id), [id2]);
+  });
+
+  test('delete and restore contact keeps notes and reminders', () async {
+    final contact = _sampleContact(category: 'Партнёр');
+    final contactId = await db.insert(contact);
+
+    final note = Note(
+      contactId: contactId,
+      text: 'Важная заметка',
+      createdAt: DateTime.now(),
+    );
+    await db.insertNote(note);
+
+    final reminder = Reminder(
+      contactId: contactId,
+      dueAt: DateTime.now().add(const Duration(hours: 5)),
+      text: 'Связаться',
+    );
+    await db.insertReminder(reminder);
+
+    final snapshot = await db.deleteContactWithSnapshot(contactId);
+    expect(snapshot.notes.length, 1);
+    expect(snapshot.reminders.length, 1);
+
+    // ensure contact removed
+    final countAfterDelete = await db.countByCategory('Партнёр');
+    expect(countAfterDelete, 0);
+
+    final restoredId = await db.restoreContactWithRelations(
+      contact.copyWith(id: null),
+      snapshot,
+    );
+
+    final restoredNotes = await db.notesByContact(restoredId);
+    expect(restoredNotes.length, 1);
+    expect(restoredNotes.first.text, 'Важная заметка');
+    expect(restoredNotes.first.contactId, restoredId);
+
+    final restoredReminders = await db.remindersByContact(restoredId);
+    expect(restoredReminders.length, 1);
+    expect(restoredReminders.first.text, 'Связаться');
+    expect(restoredReminders.first.contactId, restoredId);
+  });
+}


### PR DESCRIPTION
## Summary
- add a Reminder model plus database migration, CRUD helpers, and cascade snapshot handling
- extend contact list and details flows to snapshot and restore reminders alongside notes
- provide UI screens to add, view, and edit reminders and cover persistence with service tests

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d679877c1083289e6f7350a54e4dcf