### PR TITLE
Add reminder scheduling with local notifications

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application
         android:label="touchnotebookbeta_flutter"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,16 +34,20 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UISupportedInterfaceOrientations~ipad</key>
+        <array>
+                <string>UIInterfaceOrientationPortrait</string>
+                <string>UIInterfaceOrientationPortraitUpsideDown</string>
+                <string>UIInterfaceOrientationLandscapeLeft</string>
+                <string>UIInterfaceOrientationLandscapeRight</string>
+        </array>
+        <key>UIBackgroundModes</key>
+        <array>
+                <string>processing</string>
+        </array>
+        <key>CADisableMinimumFrameDurationOnPhone</key>
+        <true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,17 @@
 import 'package:flutter/material.dart';
 
 import 'app.dart';
+import 'services/reminder_notification_service.dart';
+import 'services/reminder_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await ReminderNotificationService.instance.initialize();
+  await ReminderNotificationService.instance.requestPermissionsIfNeeded();
+  await ReminderService.instance.rescheduleAllUpcoming();
   runApp(const App());
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    ReminderNotificationService.instance.processPendingNavigation();
+  });
 }
 

--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class Reminder {
+  final int? id;
+  final int contactId;
+  final String text;
+  final DateTime scheduledTime;
+
+  const Reminder({
+    this.id,
+    required this.contactId,
+    required this.text,
+    required this.scheduledTime,
+  });
+
+  Reminder copyWith({
+    int? id,
+    int? contactId,
+    String? text,
+    DateTime? scheduledTime,
+  }) {
+    return Reminder(
+      id: id ?? this.id,
+      contactId: contactId ?? this.contactId,
+      text: text ?? this.text,
+      scheduledTime: scheduledTime ?? this.scheduledTime,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'contactId': contactId,
+        'text': text,
+        'scheduledTime': scheduledTime.millisecondsSinceEpoch,
+      };
+
+  factory Reminder.fromMap(Map<String, dynamic> map) => Reminder(
+        id: map['id'] as int?,
+        contactId: map['contactId'] as int,
+        text: map['text'] as String,
+        scheduledTime: DateTime.fromMillisecondsSinceEpoch(map['scheduledTime'] as int),
+      );
+}

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -8,8 +8,11 @@ import 'package:overlay_support/overlay_support.dart';
 
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
 import '../services/contact_database.dart';
+import '../services/reminder_service.dart';
 import '../widgets/system_notifications.dart';
+import '../widgets/add_reminder_dialog.dart';
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
 import 'contact_list_screen.dart';
@@ -51,6 +54,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   // --- keys для автоскролла к самим карточкам ---
   final _extraCardKey = GlobalKey();
+  final _remindersCardKey = GlobalKey();
   final _notesCardKey = GlobalKey();
 
   IconData _statusIcon(String s) {
@@ -81,6 +85,44 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
           Text(
             DateFormat('dd.MM.yyyy').format(note.createdAt),
             style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+          ),
+        ],
+      ),
+      onTap: null,
+      isLast: isLast,
+    );
+  }
+
+  Widget _reminderRow(Reminder reminder, {bool isLast = false}) {
+    final theme = Theme.of(context);
+    final formattedDate = DateFormat('d MMMM yyyy, HH:mm', 'ru').format(reminder.scheduledTime);
+    return _sheetRow(
+      leading: const Icon(Icons.alarm_outlined),
+      right: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  reminder.text,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  formattedDate,
+                  style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () => _deleteReminder(reminder),
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Удалить',
           ),
         ],
       ),
@@ -503,8 +545,10 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   bool _addedOpen = false;
 
   bool _extraExpanded = false; // «Дополнительно»
+  bool _remindersExpanded = true; // «Напоминания» открыто
   bool _notesExpanded = true; // «Заметки» открыто
   List<Note> _notes = [];
+  List<Reminder> _reminders = [];
 
   // FocusNodes — для подсветки/навигации
   final FocusNode _focusBirth = FocusNode(skipTraversal: true);
@@ -549,6 +593,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     _contact = widget.contact;
     _loadFromContact();
     _loadNotes();
+    _loadReminders();
     // чтобы превью обновлялось при каждом символе
     _phoneController.addListener(() => setState(() {}));
     _nameController.addListener(() => setState(() {}));
@@ -586,6 +631,12 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     if (mounted) setState(() => _notes = notes);
   }
 
+  Future<void> _loadReminders() async {
+    if (_contact.id == null) return;
+    final reminders = await ReminderService.instance.remindersByContact(_contact.id!);
+    if (mounted) setState(() => _reminders = reminders);
+  }
+
   Future<void> _addNote() async {
     if (_contact.id == null) return;
     final note = await Navigator.push<Note>(
@@ -599,6 +650,36 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       if (!mounted) return;
       showSuccessBanner('Заметка добавлена');
     }
+  }
+
+  Future<void> _addReminder() async {
+    if (_contact.id == null) {
+      showWarningBanner('Сохраните контакт перед добавлением напоминаний');
+      return;
+    }
+    final draft = await showAddReminderDialog(context);
+    if (draft == null) return;
+
+    try {
+      await ReminderService.instance.createReminder(
+        contactId: _contact.id!,
+        text: draft.text,
+        scheduledTime: draft.scheduledAt,
+      );
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание создано');
+    } catch (e) {
+      if (!mounted) return;
+      showWarningBanner('Не удалось создать напоминание');
+    }
+  }
+
+  Future<void> _deleteReminder(Reminder reminder) async {
+    await ReminderService.instance.deleteReminder(reminder);
+    await _loadReminders();
+    if (!mounted) return;
+    showSuccessBanner('Напоминание удалено');
   }
 
   // ==================== helpers ====================
@@ -1071,8 +1152,10 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     if (c.id == null) return;
 
     final db = ContactDatabase.instance;
+    final reminderService = ReminderService.instance;
 
     // Удаляем контакт и забираем снапшот заметок для возможного Undo
+    final remindersSnapshot = await reminderService.snapshotAndCancelByContact(c.id!);
     final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
 
     // Показываем баннер с Undo
@@ -1085,6 +1168,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       onUndo: () async {
         _undoBanner = null;
         final newId = await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+        await reminderService.restoreReminders(newId, remindersSnapshot);
 
         // Сообщаем открытому списку: локально добавить и подсветить (без автоскролла)
         ContactListScreen.notifyRestoredIfMounted(c, newId);
@@ -1609,6 +1693,69 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     // Соцсеть — верхний хинт показываем, если пусто
                     _socialPickerField(),
                   ],
+                ),
+              ),
+
+              // ===== Блок: Напоминания =====
+              KeyedSubtree(
+                key: _remindersCardKey,
+                child: _collapsibleSectionCard(
+                  title: 'Напоминания',
+                  expanded: _remindersExpanded,
+                  onChanged: (v) {
+                    setState(() => _remindersExpanded = v);
+                    if (v) _scrollToCard(_remindersCardKey);
+                  },
+                  headerActions: [
+                    TextButton.icon(
+                      onPressed: _contact.id == null ? null : _addReminder,
+                      icon: const Icon(Icons.add_alarm_outlined),
+                      label: const Text('Добавить'),
+                    ),
+                  ],
+                  children: _reminders.isEmpty
+                      ? [
+                          Card(
+                            elevation: 0,
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(
+                                    Icons.alarm_outlined,
+                                    size: 48,
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Text(
+                                    _contact.id == null
+                                        ? 'Сохраните контакт, чтобы добавлять напоминания'
+                                        : 'Нет напоминаний',
+                                    style: Theme.of(context).textTheme.titleMedium,
+                                    textAlign: TextAlign.center,
+                                  ),
+                                  const SizedBox(height: 24),
+                                  FilledButton.icon(
+                                    onPressed: _contact.id == null ? null : _addReminder,
+                                    icon: const Icon(Icons.add),
+                                    label: const Text('Добавить напоминание'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ]
+                      : [
+                          Card(
+                            elevation: 0,
+                            child: Column(
+                              children: [
+                                for (var i = 0; i < _reminders.length; i++)
+                                  _reminderRow(_reminders[i], isLast: i == _reminders.length - 1),
+                              ],
+                            ),
+                          ),
+                        ],
                 ),
               ),
 

--- a/lib/services/reminder_notification_service.dart
+++ b/lib/services/reminder_notification_service.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+import '../app.dart';
+import '../models/reminder.dart';
+import '../screens/contact_details_screen.dart';
+import 'contact_database.dart';
+
+const _androidChannelId = 'contact_reminders';
+const _androidChannelName = 'Напоминания по контактам';
+const _androidChannelDescription = 'Локальные пуш-уведомления для напоминаний о контактах.';
+
+@pragma('vm:entry-point')
+void reminderNotificationTapBackground(NotificationResponse response) {}
+
+class ReminderNotificationService {
+  ReminderNotificationService._();
+  static final ReminderNotificationService instance = ReminderNotificationService._();
+
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+  bool _initialized = false;
+  NotificationResponse? _pendingNavigationResponse;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+
+    tz.initializeTimeZones();
+    try {
+      final timezoneName = await FlutterTimezone.getLocalTimezone();
+      tz.setLocalLocation(tz.getLocation(timezoneName));
+    } catch (_) {
+      // Если не удалось определить локальную таймзону, используем системную по умолчанию.
+    }
+
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    final iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+    final initSettings = InitializationSettings(android: androidSettings, iOS: iosSettings);
+
+    final details = await _plugin.getNotificationAppLaunchDetails();
+
+    await _plugin.initialize(
+      initSettings,
+      onDidReceiveNotificationResponse: handleNotificationResponse,
+      onDidReceiveBackgroundNotificationResponse: reminderNotificationTapBackground,
+    );
+
+    final androidImpl =
+        _plugin.resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+    await androidImpl?.requestNotificationsPermission();
+    await androidImpl?.requestExactAlarmsPermission();
+
+    _initialized = true;
+
+    if (details?.didNotificationLaunchApp ?? false) {
+      _pendingNavigationResponse = details!.notificationResponse;
+    }
+  }
+
+  Future<void> requestPermissionsIfNeeded() async {
+    final iosImpl = _plugin.resolvePlatformSpecificImplementation<DarwinFlutterLocalNotificationsPlugin>();
+    await iosImpl?.requestPermissions(alert: true, badge: true, sound: true);
+  }
+
+  Future<void> scheduleReminder(Reminder reminder) async {
+    if (reminder.id == null) {
+      throw ArgumentError('Reminder id is required to schedule a notification');
+    }
+
+    await _plugin.cancel(reminder.id!);
+
+    final scheduled = tz.TZDateTime.from(reminder.scheduledTime, tz.local);
+    if (scheduled.isBefore(tz.TZDateTime.now(tz.local))) {
+      return;
+    }
+
+    final androidDetails = AndroidNotificationDetails(
+      _androidChannelId,
+      _androidChannelName,
+      channelDescription: _androidChannelDescription,
+      importance: Importance.max,
+      priority: Priority.high,
+      enableVibration: true,
+      ticker: reminder.text,
+    );
+    const iosDetails = DarwinNotificationDetails(presentSound: true);
+    final notificationDetails = NotificationDetails(android: androidDetails, iOS: iosDetails);
+
+    final payload = jsonEncode({
+      'contactId': reminder.contactId,
+      'reminderId': reminder.id,
+    });
+
+    await _plugin.zonedSchedule(
+      reminder.id!,
+      'Напоминание по контакту',
+      reminder.text,
+      scheduled,
+      notificationDetails,
+      uiLocalNotificationDateInterpretation: UILocalNotificationDateInterpretation.absoluteTime,
+      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      payload: payload,
+    );
+  }
+
+  Future<void> cancelReminder(int reminderId) async {
+    await _plugin.cancel(reminderId);
+  }
+
+  Future<void> cancelReminders(Iterable<int> reminderIds) async {
+    for (final id in reminderIds) {
+      await _plugin.cancel(id);
+    }
+  }
+
+  Future<void> cancelAll() => _plugin.cancelAll();
+
+  Future<void> handleNotificationResponse(NotificationResponse response) async {
+    if (response.payload == null || response.payload!.isEmpty) {
+      return;
+    }
+    // Если навигатор ещё не готов (например, приложение только запускается),
+    // откладываем обработку.
+    if (App.navigatorKey.currentState == null) {
+      _pendingNavigationResponse = response;
+      return;
+    }
+
+    final data = jsonDecode(response.payload!) as Map<String, dynamic>;
+    final contactId = data['contactId'] as int?;
+    if (contactId == null) return;
+
+    final contact = await ContactDatabase.instance.contactById(contactId);
+    if (contact == null) return;
+
+    // Уже открытый экран контакта перезапускаем, чтобы не копить стек.
+    App.navigatorKey.currentState!
+      ..popUntil((route) => route.isFirst)
+      ..push(MaterialPageRoute(builder: (_) => ContactDetailsScreen(contact: contact)));
+  }
+
+  Future<void> processPendingNavigation() async {
+    if (_pendingNavigationResponse == null) return;
+    final response = _pendingNavigationResponse!;
+    _pendingNavigationResponse = null;
+    await handleNotificationResponse(response);
+  }
+}

--- a/lib/services/reminder_service.dart
+++ b/lib/services/reminder_service.dart
@@ -1,0 +1,73 @@
+import '../models/reminder.dart';
+import 'contact_database.dart';
+import 'reminder_notification_service.dart';
+
+class ReminderService {
+  ReminderService._();
+  static final ReminderService instance = ReminderService._();
+
+  final ContactDatabase _db = ContactDatabase.instance;
+  final ReminderNotificationService _notifications = ReminderNotificationService.instance;
+
+  Future<Reminder> createReminder({
+    required int contactId,
+    required String text,
+    required DateTime scheduledTime,
+  }) async {
+    final reminder = Reminder(contactId: contactId, text: text.trim(), scheduledTime: scheduledTime);
+    final id = await _db.insertReminder(reminder);
+    final saved = reminder.copyWith(id: id);
+    await _notifications.scheduleReminder(saved);
+    return saved;
+  }
+
+  Future<List<Reminder>> remindersByContact(int contactId) {
+    return _db.remindersByContact(contactId);
+  }
+
+  Future<void> deleteReminder(Reminder reminder) async {
+    if (reminder.id != null) {
+      await _notifications.cancelReminder(reminder.id!);
+      await _db.deleteReminder(reminder.id!);
+    }
+  }
+
+  Future<void> deleteRemindersByContact(int contactId) async {
+    final reminders = await _db.remindersByContact(contactId);
+    final ids = reminders.map((r) => r.id).whereType<int>().toList();
+    if (ids.isNotEmpty) {
+      await _notifications.cancelReminders(ids);
+    }
+    // Удалять вручную не нужно — каскад сделает это сам, но вызовем для верности.
+    for (final id in ids) {
+      await _db.deleteReminder(id);
+    }
+  }
+
+  Future<List<Reminder>> snapshotAndCancelByContact(int contactId) async {
+    final reminders = await _db.remindersByContact(contactId);
+    final ids = reminders.map((r) => r.id).whereType<int>().toList();
+    if (ids.isNotEmpty) {
+      await _notifications.cancelReminders(ids);
+    }
+    return reminders;
+  }
+
+  Future<void> rescheduleAllUpcoming() async {
+    final reminders = await _db.remindersScheduledAfter(DateTime.now());
+    for (final reminder in reminders) {
+      await _notifications.scheduleReminder(reminder);
+    }
+  }
+
+  Future<void> restoreReminders(int newContactId, List<Reminder> reminders) async {
+    for (final reminder in reminders) {
+      final restored = reminder.copyWith(id: null, contactId: newContactId);
+      await createReminder(
+        contactId: restored.contactId,
+        text: restored.text,
+        scheduledTime: restored.scheduledTime,
+      );
+    }
+  }
+}

--- a/lib/widgets/add_reminder_dialog.dart
+++ b/lib/widgets/add_reminder_dialog.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ReminderDraft {
+  final String text;
+  final DateTime scheduledAt;
+
+  ReminderDraft({required this.text, required this.scheduledAt});
+}
+
+Future<ReminderDraft?> showAddReminderDialog(BuildContext context) {
+  return showDialog<ReminderDraft>(
+    context: context,
+    builder: (context) => const _ReminderDialog(),
+  );
+}
+
+class _ReminderDialog extends StatefulWidget {
+  const _ReminderDialog();
+
+  @override
+  State<_ReminderDialog> createState() => _ReminderDialogState();
+}
+
+class _ReminderDialogState extends State<_ReminderDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _textController = TextEditingController();
+  DateTime? _selectedDate;
+  TimeOfDay? _selectedTime;
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate() async {
+    final now = DateTime.now();
+    final date = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate ?? now,
+      firstDate: now,
+      lastDate: DateTime(now.year + 5),
+    );
+    if (date != null) {
+      setState(() => _selectedDate = date);
+    }
+  }
+
+  Future<void> _pickTime() async {
+    final time = await showTimePicker(
+      context: context,
+      initialTime: _selectedTime ?? TimeOfDay.now(),
+    );
+    if (time != null) {
+      setState(() => _selectedTime = time);
+    }
+  }
+
+  DateTime? get _scheduledDateTime {
+    final date = _selectedDate;
+    final time = _selectedTime;
+    if (date == null || time == null) return null;
+    final scheduled = DateTime(date.year, date.month, date.day, time.hour, time.minute);
+    if (scheduled.isBefore(DateTime.now())) return null;
+    return scheduled;
+  }
+
+  void _submit() {
+    if (_submitting) return;
+    final scheduled = _scheduledDateTime;
+    if (!_formKey.currentState!.validate() || scheduled == null) {
+      if (scheduled == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Выберите дату и время в будущем')),
+        );
+      }
+      return;
+    }
+    setState(() => _submitting = true);
+    Navigator.of(context).pop(ReminderDraft(text: _textController.text.trim(), scheduledAt: scheduled));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateText = _selectedDate == null
+        ? 'Выбрать дату'
+        : DateFormat.yMMMMd('ru').format(_selectedDate!);
+    final timeText = _selectedTime == null
+        ? 'Выбрать время'
+        : _selectedTime!.format(context);
+
+    return AlertDialog(
+      title: const Text('Добавить напоминание'),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextFormField(
+              controller: _textController,
+              decoration: const InputDecoration(
+                labelText: 'Текст напоминания',
+              ),
+              maxLines: 2,
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Введите текст напоминания';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _pickDate,
+                    icon: const Icon(Icons.event_outlined),
+                    label: Text(dateText, style: theme.textTheme.bodyMedium),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _pickTime,
+                    icon: const Icon(Icons.access_time),
+                    label: Text(timeText, style: theme.textTheme.bodyMedium),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _submitting ? null : () => Navigator.of(context).pop(),
+          child: const Text('Отмена'),
+        ),
+        FilledButton(
+          onPressed: _submitting ? null : _submit,
+          child: const Text('Сохранить'),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,9 @@ dependencies:
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
   overlay_support: ^2.1.0
+  flutter_local_notifications: ^17.1.2
+  timezone: ^0.9.4
+  flutter_timezone: ^1.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a Reminder model with SQLite CRUD support and new scheduling services
- integrate reminder creation, listing, and deletion into the contact details screen with notification handling
- configure Android/iOS permissions and initialization for background local notifications

## Testing
- Not run (Flutter SDK not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d68367a00c83288f90078b79750e46