### PR TITLE
Add demo push notification action

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -42,6 +42,8 @@ abstract class R {
       'Создайте первый контакт. Ниже можно открыть списки по категориям.';
   static const chipHintOpenList = 'Откройте список по категории';
   static const dataUpdated = 'Данные обновлены';
+  static const showNotification = 'Показать уведомление';
+  static const notificationMessage = 'Это тестовое push-уведомление.';
 
   static String summaryUnknown(int count) {
     if (count <= 0) return summaryAllKnown;
@@ -365,7 +367,16 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
   Widget build(BuildContext context) {
     return Scaffold(
       restorationId: 'home_scaffold',
-      appBar: AppBar(title: const Text(R.homeTitle)),
+      appBar: AppBar(
+        title: const Text(R.homeTitle),
+        actions: [
+          IconButton(
+            tooltip: R.showNotification,
+            icon: const Icon(Icons.notifications_active_outlined),
+            onPressed: _showDemoNotification,
+          ),
+        ],
+      ),
       drawer: NavigationDrawer(
         selectedIndex: _drawerIndex.value,
         onDestinationSelected: (index) {
@@ -591,6 +602,13 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
         label: const Text(R.addContact),
         icon: const Icon(Icons.person_add),
       ),
+    );
+  }
+
+  void _showDemoNotification() {
+    showSystemNotification(
+      R.notificationMessage,
+      style: SystemNotificationStyle.success,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add a notification shortcut to the home screen app bar
- display a demo push banner using the existing overlay notification helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d68bad1c788328aed56f99de219e85