### PR TITLE
Add demo system push notification

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 import 'app.dart';
+import 'services/push_notifications.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await PushNotifications.ensureInitialized();
   runApp(const App());
 }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ import 'add_contact_screen.dart';
 import 'settings_screen.dart';
 import 'contact_list_screen.dart';
 import '../services/contact_database.dart';
+import '../services/push_notifications.dart';
 import '../widgets/system_notifications.dart';
 
 /// ---------------------
@@ -42,6 +43,9 @@ abstract class R {
       'Создайте первый контакт. Ниже можно открыть списки по категориям.';
   static const chipHintOpenList = 'Откройте список по категории';
   static const dataUpdated = 'Данные обновлены';
+  static const showNotification = 'Показать уведомление';
+  static const notificationMessage = 'Это тестовое push-уведомление.';
+  static const notificationSent = 'Системное push-уведомление отправлено';
 
   static String summaryUnknown(int count) {
     if (count <= 0) return summaryAllKnown;
@@ -365,7 +369,16 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
   Widget build(BuildContext context) {
     return Scaffold(
       restorationId: 'home_scaffold',
-      appBar: AppBar(title: const Text(R.homeTitle)),
+      appBar: AppBar(
+        title: const Text(R.homeTitle),
+        actions: [
+          IconButton(
+            tooltip: R.showNotification,
+            icon: const Icon(Icons.notifications_active_outlined),
+            onPressed: _showDemoNotification,
+          ),
+        ],
+      ),
       drawer: NavigationDrawer(
         selectedIndex: _drawerIndex.value,
         onDestinationSelected: (index) {
@@ -591,6 +604,19 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
         label: const Text(R.addContact),
         icon: const Icon(Icons.person_add),
       ),
+    );
+  }
+
+  Future<void> _showDemoNotification() async {
+    await PushNotifications.showNotification(
+      id: 1001,
+      title: R.appTitle,
+      body: R.notificationMessage,
+    );
+    if (!mounted) return;
+    showInfoBanner(
+      R.notificationSent,
+      duration: const Duration(seconds: 2),
     );
   }
 }

--- a/lib/services/push_notifications.dart
+++ b/lib/services/push_notifications.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class PushNotifications {
+  PushNotifications._();
+
+  static final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  static bool _initialized = false;
+
+  static Future<void> ensureInitialized() async {
+    if (_initialized) return;
+
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const darwinInit = DarwinInitializationSettings(
+      requestAlertPermission: true,
+      requestBadgePermission: true,
+      requestSoundPermission: true,
+    );
+
+    final settings = const InitializationSettings(
+      android: androidInit,
+      iOS: darwinInit,
+      macOS: darwinInit,
+    );
+
+    await _plugin.initialize(settings);
+
+    // Android 13+ permission request
+    final androidImplementation = _plugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    if (androidImplementation != null) {
+      await androidImplementation.requestNotificationsPermission();
+    }
+
+    // iOS/macOS permission request
+    final appleImplementation =
+        _plugin.resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>();
+    if (appleImplementation != null) {
+      await appleImplementation.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+    }
+
+    final macImplementation = _plugin.resolvePlatformSpecificImplementation<
+        MacOSFlutterLocalNotificationsPlugin>();
+    if (macImplementation != null) {
+      await macImplementation.requestPermissions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+    }
+
+    _initialized = true;
+  }
+
+  static Future<void> showNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    await ensureInitialized();
+
+    const androidDetails = AndroidNotificationDetails(
+      'demo_push_channel',
+      'Демо уведомления',
+      channelDescription: 'Канал для тестовых push-уведомлений',
+      importance: Importance.max,
+      priority: Priority.high,
+    );
+
+    const darwinDetails = DarwinNotificationDetails();
+
+    final details = const NotificationDetails(
+      android: androidDetails,
+      iOS: darwinDetails,
+      macOS: darwinDetails,
+    );
+
+    try {
+      await _plugin.show(id, title, body, details);
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        // ignore: avoid_print
+        print('Failed to show notification: $error\n$stackTrace');
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
   overlay_support: ^2.1.0
+  flutter_local_notifications: ^17.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add flutter_local_notifications dependency and a push notification helper service
- initialize local notifications on startup and trigger a system push from the home screen action

## Testing
- `flutter pub get` *(fails: Flutter SDK not available in container)*
- `dart format lib/main.dart lib/screens/home_screen.dart lib/services/push_notifications.dart` *(fails: Dart SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d68bad1c788328aed56f99de219e85