### PR TITLE
Downgrade local notifications plugin for DateTime scheduling

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,26 +98,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
+      sha256: "3f1bcab141b958e00ab61b21c291685e3bfd7cc69dbd72cf0ca08508bcb61396"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.4"
+    version: "16.3.2"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      sha256: "5be9374b22acaf4b0ad1fd045b55bd7f28a427a1db8870c3f1d3c6e288d9515d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "3.1.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      sha256: "4ac80eae1f9b76db31b44b752d31b2576f6347382722f92f47dc73a0b9a96d47"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.1.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   intl: ^0.20.2
   mask_text_input_formatter: ^2.4.0
   overlay_support: ^2.1.0
-  flutter_local_notifications: ^17.2.1
+  flutter_local_notifications: ^16.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- downgrade flutter_local_notifications to the 16.3.2 release that still exposes the DateTime-based schedule helper
- update the lockfile to match the downgraded plugin and transitive packages

## Testing
- not run (Flutter SDK not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d69c08da408328b0fe4ec2d88669d1