### PR TITLE
Add contact reminders with scheduled notifications

### DIFF
--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -1,0 +1,48 @@
+class Reminder {
+  final int? id;
+  final int contactId;
+  final String text;
+  final DateTime remindAt;
+  final DateTime createdAt;
+
+  const Reminder({
+    this.id,
+    required this.contactId,
+    required this.text,
+    required this.remindAt,
+    required this.createdAt,
+  });
+
+  Reminder copyWith({
+    int? id,
+    int? contactId,
+    String? text,
+    DateTime? remindAt,
+    DateTime? createdAt,
+  }) =>
+      Reminder(
+        id: id ?? this.id,
+        contactId: contactId ?? this.contactId,
+        text: text ?? this.text,
+        remindAt: remindAt ?? this.remindAt,
+        createdAt: createdAt ?? this.createdAt,
+      );
+
+  Map<String, Object?> toMap() => {
+        'id': id,
+        'contactId': contactId,
+        'text': text,
+        'remindAt': remindAt.millisecondsSinceEpoch,
+        'createdAt': createdAt.millisecondsSinceEpoch,
+      };
+
+  factory Reminder.fromMap(Map<String, Object?> map) => Reminder(
+        id: map['id'] as int?,
+        contactId: map['contactId'] as int,
+        text: map['text'] as String,
+        remindAt:
+            DateTime.fromMillisecondsSinceEpoch(map['remindAt'] as int),
+        createdAt:
+            DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+      );
+}

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -8,7 +8,9 @@ import 'package:overlay_support/overlay_support.dart';
 
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
 import '../services/contact_database.dart';
+import '../services/push_notifications.dart';
 import '../widgets/system_notifications.dart';
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
@@ -51,6 +53,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   // --- keys для автоскролла к самим карточкам ---
   final _extraCardKey = GlobalKey();
+  final _remindersCardKey = GlobalKey();
   final _notesCardKey = GlobalKey();
 
   IconData _statusIcon(String s) {
@@ -62,6 +65,49 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       case 'Тёплый':     return Icons.local_fire_department;
       default:           return Icons.label_outline;
     }
+  }
+
+  Widget _reminderRow(Reminder reminder, {bool isLast = false}) {
+    final theme = Theme.of(context);
+    final dateLabel = DateFormat('dd.MM.yyyy HH:mm').format(reminder.remindAt);
+    final isPast = reminder.remindAt.isBefore(DateTime.now());
+
+    return _sheetRow(
+      leading: const Icon(Icons.notifications_active_outlined),
+      right: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  reminder.text,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  dateLabel,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: isPast
+                        ? theme.colorScheme.error
+                        : theme.hintColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Удалить напоминание',
+            onPressed: () => _confirmDeleteReminder(reminder),
+          ),
+        ],
+      ),
+      isLast: isLast,
+    );
   }
 
   Widget _noteRow(Note note, {bool isLast = false}) {
@@ -503,6 +549,8 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   bool _addedOpen = false;
 
   bool _extraExpanded = false; // «Дополнительно»
+  bool _remindersExpanded = true; // «Напоминания» открыто
+  List<Reminder> _reminders = [];
   bool _notesExpanded = true; // «Заметки» открыто
   List<Note> _notes = [];
 
@@ -548,6 +596,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     super.initState();
     _contact = widget.contact;
     _loadFromContact();
+    _loadReminders();
     _loadNotes();
     // чтобы превью обновлялось при каждом символе
     _phoneController.addListener(() => setState(() {}));
@@ -580,6 +629,13 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     super.dispose();
   }
 
+  Future<void> _loadReminders() async {
+    if (_contact.id == null) return;
+    final reminders =
+        await ContactDatabase.instance.remindersByContact(_contact.id!);
+    if (mounted) setState(() => _reminders = reminders);
+  }
+
   Future<void> _loadNotes() async {
     if (_contact.id == null) return;
     final notes = await ContactDatabase.instance.lastNotesByContact(_contact.id!, limit: 3);
@@ -599,6 +655,190 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       if (!mounted) return;
       showSuccessBanner('Заметка добавлена');
     }
+  }
+
+  Future<void> _addReminder() async {
+    if (_contact.id == null) {
+      showErrorBanner('Сохраните контакт, чтобы добавить напоминание');
+      return;
+    }
+
+    final result = await _showReminderDialog();
+    if (result == null) return;
+
+    final text = result.text.trim();
+    final when = result.when;
+    if (when.isBefore(DateTime.now())) {
+      showErrorBanner('Выберите время в будущем');
+      return;
+    }
+
+    final reminder = Reminder(
+      contactId: _contact.id!,
+      text: text,
+      remindAt: when,
+      createdAt: DateTime.now(),
+    );
+
+    try {
+      final id = await ContactDatabase.instance.insertReminder(reminder);
+      final saved = reminder.copyWith(id: id);
+
+      await PushNotifications.scheduleOneTime(
+        id: saved.id!,
+        whenLocal: saved.remindAt,
+        title: 'Напоминание: ${_contact.name}',
+        body: saved.text,
+      );
+
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание добавлено');
+    } catch (e) {
+      if (mounted) {
+        showErrorBanner('Не удалось сохранить напоминание: $e');
+      }
+    }
+  }
+
+  Future<void> _confirmDeleteReminder(Reminder reminder) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: const Text('Напоминание будет удалено и уведомление отменено.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+
+    final reminderId = reminder.id;
+    if (reminderId == null) return;
+
+    try {
+      await ContactDatabase.instance.deleteReminder(reminderId);
+      await PushNotifications.cancel(reminderId);
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание удалено');
+    } catch (e) {
+      if (mounted) {
+        showErrorBanner('Не удалось удалить напоминание: $e');
+      }
+    }
+  }
+
+  Future<({String text, DateTime when})?> _showReminderDialog() async {
+    final controller = TextEditingController();
+    var selected = DateTime.now().add(const Duration(minutes: 5));
+
+    return showDialog<({String text, DateTime when})>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            final dateLabel = DateFormat('dd.MM.yyyy').format(selected);
+            final timeLabel = DateFormat('HH:mm').format(selected);
+
+            return AlertDialog(
+              title: const Text('Новое напоминание'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: controller,
+                    maxLines: 3,
+                    autofocus: true,
+                    decoration: const InputDecoration(
+                      labelText: 'Текст напоминания',
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.event_outlined),
+                    title: Text(dateLabel),
+                    subtitle: const Text('Дата'),
+                    onTap: () async {
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: selected,
+                        firstDate: DateTime.now(),
+                        lastDate: DateTime.now().add(const Duration(days: 365 * 5)),
+                        helpText: 'Выберите дату',
+                      );
+                      if (picked != null) {
+                        setState(() {
+                          selected = DateTime(
+                            picked.year,
+                            picked.month,
+                            picked.day,
+                            selected.hour,
+                            selected.minute,
+                          );
+                        });
+                      }
+                    },
+                  ),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.schedule_outlined),
+                    title: Text(timeLabel),
+                    subtitle: const Text('Время'),
+                    onTap: () async {
+                      final picked = await showTimePicker(
+                        context: context,
+                        initialTime:
+                            TimeOfDay(hour: selected.hour, minute: selected.minute),
+                        helpText: 'Выберите время',
+                      );
+                      if (picked != null) {
+                        setState(() {
+                          selected = DateTime(
+                            selected.year,
+                            selected.month,
+                            selected.day,
+                            picked.hour,
+                            picked.minute,
+                          );
+                        });
+                      }
+                    },
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Отмена'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    final text = controller.text.trim();
+                    if (text.isEmpty) {
+                      showErrorBanner('Введите текст напоминания');
+                      return;
+                    }
+                    Navigator.pop(context, (text: text, when: selected));
+                  },
+                  child: const Text('Сохранить'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
   }
 
   // ==================== helpers ====================
@@ -1072,8 +1312,17 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
     final db = ContactDatabase.instance;
 
-    // Удаляем контакт и забираем снапшот заметок для возможного Undo
-    final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
+    // Удаляем контакт и забираем снапшот заметок/напоминаний для возможного Undo
+    final snapshot = await db.deleteContactWithSnapshot(c.id!);
+    final notesSnapshot = snapshot.notes;
+    final remindersSnapshot = snapshot.reminders;
+
+    for (final reminder in remindersSnapshot) {
+      final reminderId = reminder.id;
+      if (reminderId != null) {
+        await PushNotifications.cancel(reminderId);
+      }
+    }
 
     // Показываем баннер с Undo
     _undoBanner?.dismiss();
@@ -1084,14 +1333,32 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       icon: Icons.delete_outline,
       onUndo: () async {
         _undoBanner = null;
-        final newId = await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+        final newId = await db.restoreContactWithNotes(
+          c.copyWith(id: null),
+          notesSnapshot,
+          remindersSnapshot,
+        );
 
         // Сообщаем открытому списку: локально добавить и подсветить (без автоскролла)
         ContactListScreen.notifyRestoredIfMounted(c, newId);
+
+        // Возвращаем напоминания
+        final restoredReminders = await db.remindersByContact(newId);
+        for (final reminder in restoredReminders) {
+          if (reminder.remindAt.isAfter(DateTime.now()) && reminder.id != null) {
+            await PushNotifications.scheduleOneTime(
+              id: reminder.id!,
+              whenLocal: reminder.remindAt,
+              title: 'Напоминание: ${c.name}',
+              body: reminder.text,
+            );
+          }
+        }
+
         showSystemNotification(
-        'Контакт восстановлен',
-        style: SystemNotificationStyle.success,
-        iconOverride: Icons.undo,
+          'Контакт восстановлен',
+          style: SystemNotificationStyle.success,
+          iconOverride: Icons.undo,
         );
       },
     );
@@ -1609,6 +1876,83 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     // Соцсеть — верхний хинт показываем, если пусто
                     _socialPickerField(),
                   ],
+                ),
+              ),
+
+              // ===== Блок: Напоминания =====
+              KeyedSubtree(
+                key: _remindersCardKey,
+                child: _collapsibleSectionCard(
+                  title: 'Напоминания',
+                  expanded: _remindersExpanded,
+                  onChanged: (v) {
+                    setState(() => _remindersExpanded = v);
+                    if (v) _scrollToCard(_remindersCardKey);
+                  },
+                  headerActions: [
+                    IconButton(
+                      tooltip: 'Добавить напоминание',
+                      onPressed: _contact.id == null ? null : _addReminder,
+                      icon: const Icon(Icons.add_alert_outlined),
+                    ),
+                  ],
+                  children: _reminders.isEmpty
+                      ? [
+                          Card(
+                            elevation: 0,
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(
+                                    Icons.notifications_active_outlined,
+                                    size: 48,
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Text(
+                                    _contact.id == null
+                                        ? 'Сохраните контакт, чтобы добавлять напоминания'
+                                        : 'Нет напоминаний',
+                                    style: Theme.of(context).textTheme.titleMedium,
+                                    textAlign: TextAlign.center,
+                                  ),
+                                  const SizedBox(height: 24),
+                                  FilledButton.icon(
+                                    onPressed:
+                                        _contact.id == null ? null : _addReminder,
+                                    icon: const Icon(Icons.add),
+                                    label: const Text('Добавить напоминание'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ]
+                      : [
+                          Card(
+                            elevation: 0,
+                            child: Column(
+                              children: [
+                                for (var i = 0; i < _reminders.length; i++)
+                                  _reminderRow(
+                                    _reminders[i],
+                                    isLast: i == _reminders.length - 1,
+                                  ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: FilledButton.icon(
+                              onPressed:
+                                  _contact.id == null ? null : _addReminder,
+                              icon: const Icon(Icons.add),
+                              label: const Text('Добавить напоминание'),
+                            ),
+                          ),
+                        ],
                 ),
               ),
 

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -4,7 +4,9 @@ import 'package:overlay_support/overlay_support.dart';
 
 import '../app.dart'; // для App.navigatorKey
 import '../models/contact.dart';
+import '../models/reminder.dart';
 import '../services/contact_database.dart';
+import '../services/push_notifications.dart';
 import '../widgets/system_notifications.dart';
 import 'add_contact_screen.dart';
 import 'contact_details_screen.dart';
@@ -489,8 +491,18 @@ class _ContactListScreenState extends State<ContactListScreen> {
     if (c.id == null) return;
     final db = ContactDatabase.instance;
     try {
-      // 1) Снимок заметок + удаление контакта (каскад снесёт заметки)
-      final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
+      // 1) Снимок заметок/напоминаний + удаление контакта
+      final snapshot = await db.deleteContactWithSnapshot(c.id!);
+      final notesSnapshot = snapshot.notes;
+      final remindersSnapshot = snapshot.reminders;
+
+      // Отменяем запланированные уведомления по напоминаниям
+      for (final reminder in remindersSnapshot) {
+        final reminderId = reminder.id;
+        if (reminderId != null) {
+          await PushNotifications.cancel(reminderId);
+        }
+      }
       // 2) Убираем из локального списка
       setState(() {
         _all.removeWhere((e) => e.id == c.id);
@@ -504,9 +516,25 @@ class _ContactListScreenState extends State<ContactListScreen> {
         icon: Icons.delete_outline,
         onUndo: () async {
           _undoBanner = null;
-          final newId =
-              await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+          final newId = await db.restoreContactWithNotes(
+            c.copyWith(id: null),
+            notesSnapshot,
+            remindersSnapshot,
+          );
           _restoreLocally(c.copyWith(id: newId), highlight: true);
+
+          // Восстанавливаем запланированные уведомления для будущих напоминаний
+          final restoredReminders = await db.remindersByContact(newId);
+          for (final reminder in restoredReminders) {
+            if (reminder.remindAt.isAfter(DateTime.now()) && reminder.id != null) {
+              await PushNotifications.scheduleOneTime(
+                id: reminder.id!,
+                whenLocal: reminder.remindAt,
+                title: 'Напоминание: ${c.name}',
+                body: reminder.text,
+              );
+            }
+          }
         },
       );
     } catch (e) {

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart' as p;
 import 'package:flutter/foundation.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
 
 class ContactDatabase {
   ContactDatabase._();
@@ -22,8 +23,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 2, чтобы сработала миграция с FK + CASCADE
-      version: 2,
+      // ВАЖНО: поднимаем версию до 3, чтобы сработала миграция с FK + CASCADE и напоминаниями
+      version: 3,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -65,6 +66,17 @@ class ContactDatabase {
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_category_createdAt ON contacts(category, createdAt)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(name)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
+        await db.execute('''
+          CREATE TABLE reminders(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contactId INTEGER NOT NULL,
+            text TEXT NOT NULL,
+            remindAt INTEGER NOT NULL,
+            createdAt INTEGER NOT NULL,
+            FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+          )
+        ''');
+        await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
       },
 
       onUpgrade: (db, oldV, newV) async {
@@ -101,6 +113,20 @@ class ContactDatabase {
           await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
 
           await db.execute('PRAGMA foreign_keys = ON'); // включаем обратно
+        }
+
+        if (oldV < 3) {
+          await db.execute('''
+            CREATE TABLE IF NOT EXISTS reminders(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              contactId INTEGER NOT NULL,
+              text TEXT NOT NULL,
+              remindAt INTEGER NOT NULL,
+              createdAt INTEGER NOT NULL,
+              FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+            )
+          ''');
+          await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
         }
       },
     );
@@ -260,31 +286,80 @@ class ContactDatabase {
     return maps.map(Note.fromMap).toList();
   }
 
+  // ================= Reminders =================
+
+  Future<int> insertReminder(Reminder reminder) async {
+    final db = await database;
+    final id = await db.insert('reminders', _mapForInsert(reminder.toMap()));
+    _bumpRevision();
+    return id;
+  }
+
+  Future<int> updateReminder(Reminder reminder) async {
+    final db = await database;
+    final rows = await db.update(
+      'reminders',
+      reminder.toMap(),
+      where: 'id = ?',
+      whereArgs: [reminder.id],
+    );
+    _bumpRevision();
+    return rows;
+  }
+
+  Future<int> deleteReminder(int id) async {
+    final db = await database;
+    final rows = await db.delete('reminders', where: 'id = ?', whereArgs: [id]);
+    _bumpRevision();
+    return rows;
+  }
+
+  Future<List<Reminder>> remindersByContact(int contactId) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'remindAt ASC',
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
   // ================= Helpers для Undo =================
 
-  /// Удаляет контакт (каскадно удаляются заметки) и возвращает снапшот заметок.
-  /// В UI можно сохранить возвращённый список для последующего Undo.
+  /// Удаляет контакт (каскадно удаляются заметки/напоминания) и возвращает их снапшоты.
+  /// В UI можно сохранить возвращённые списки для последующего Undo.
   ///
   /// Операция обёрнута в транзакцию, чтобы снимок и удаление были атомарными.
-  Future<List<Note>> deleteContactWithSnapshot(int contactId) async {
+  Future<({List<Note> notes, List<Reminder> reminders})> deleteContactWithSnapshot(
+      int contactId) async {
     final db = await database;
-    final snapshot = <Note>[];
+    final notes = <Note>[];
+    final reminders = <Reminder>[];
 
     await db.transaction((txn) async {
-      final maps = await txn.query(
+      final noteMaps = await txn.query(
         'notes',
         where: 'contactId = ?',
         whereArgs: [contactId],
         orderBy: 'createdAt DESC',
       );
-      snapshot.addAll(maps.map(Note.fromMap));
+      notes.addAll(noteMaps.map(Note.fromMap));
 
-      // Удаляем контакт — FK каскадно удалит связанные заметки
+      final reminderMaps = await txn.query(
+        'reminders',
+        where: 'contactId = ?',
+        whereArgs: [contactId],
+        orderBy: 'remindAt ASC',
+      );
+      reminders.addAll(reminderMaps.map(Reminder.fromMap));
+
+      // Удаляем контакт — FK каскадно удалит связанные заметки и напоминания
       await txn.delete('contacts', where: 'id = ?', whereArgs: [contactId]);
     });
 
     _bumpRevision();
-    return snapshot;
+    return (notes: notes, reminders: reminders);
   }
 
   /// Восстанавливает контакт (получает НОВЫЙ id) и возвращает его.
@@ -295,9 +370,13 @@ class ContactDatabase {
     return newId;
   }
 
-  /// Восстанавливает контакт и ВСЕ его заметки за одну транзакцию.
+  /// Восстанавливает контакт и ВСЕ его заметки/напоминания за одну транзакцию.
   /// Возвращает новый id контакта.
-  Future<int> restoreContactWithNotes(Contact contact, List<Note> notes) async {
+  Future<int> restoreContactWithNotes(
+    Contact contact,
+    List<Note> notes, [
+    List<Reminder> reminders = const [],
+  ]) async {
     final db = await database;
     int newContactId = 0;
 
@@ -309,6 +388,13 @@ class ContactDatabase {
       for (final n in notes) {
         final noteMap = _mapForInsert(n.copyWith(contactId: newContactId, id: null).toMap());
         await txn.insert('notes', noteMap);
+      }
+
+      // Вставляем напоминания с новым contactId
+      for (final r in reminders) {
+        final reminderMap =
+            _mapForInsert(r.copyWith(contactId: newContactId, id: null).toMap());
+        await txn.insert('reminders', reminderMap);
       }
     });
 

--- a/lib/services/push_notifications.dart
+++ b/lib/services/push_notifications.dart
@@ -203,8 +203,18 @@ class PushNotifications {
 
   }
 
-  static Future<void> cancel(int id) => _plugin.cancel(id);
-  static Future<void> cancelAll() => _plugin.cancelAll();
-  static Future<List<PendingNotificationRequest>> pending() =>
-      _plugin.pendingNotificationRequests();
+  static Future<void> cancel(int id) async {
+    await ensureInitialized();
+    await _plugin.cancel(id);
+  }
+
+  static Future<void> cancelAll() async {
+    await ensureInitialized();
+    await _plugin.cancelAll();
+  }
+
+  static Future<List<PendingNotificationRequest>> pending() async {
+    await ensureInitialized();
+    return _plugin.pendingNotificationRequests();
+  }
 }


### PR DESCRIPTION
## Summary
- add a Reminder model and database table with migrations and CRUD helpers
- extend contact details UI to create, list, and remove scheduled reminders per contact
- cancel or restore reminder notifications when contacts are deleted or undone and guard notification cancellation with proper initialization

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d83498b5d08325a6afa28f60ad9f37