### PR TITLE
Add reminders for contacts with notification scheduling

### DIFF
--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -1,0 +1,48 @@
+class Reminder {
+  final int? id;
+  final int contactId;
+  final DateTime remindAt;
+  final String? note;
+  final DateTime createdAt;
+
+  const Reminder({
+    this.id,
+    required this.contactId,
+    required this.remindAt,
+    this.note,
+    required this.createdAt,
+  });
+
+  Reminder copyWith({
+    int? id,
+    int? contactId,
+    DateTime? remindAt,
+    String? note,
+    DateTime? createdAt,
+  }) =>
+      Reminder(
+        id: id ?? this.id,
+        contactId: contactId ?? this.contactId,
+        remindAt: remindAt ?? this.remindAt,
+        note: note ?? this.note,
+        createdAt: createdAt ?? this.createdAt,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'contactId': contactId,
+        'remindAt': remindAt.millisecondsSinceEpoch,
+        'note': note,
+        'createdAt': createdAt.millisecondsSinceEpoch,
+      };
+
+  factory Reminder.fromMap(Map<String, dynamic> map) => Reminder(
+        id: map['id'] as int?,
+        contactId: map['contactId'] as int,
+        remindAt: DateTime.fromMillisecondsSinceEpoch(map['remindAt'] as int),
+        note: map['note'] as String?,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+      );
+
+  static int notificationId(int reminderId) => 200000 + reminderId;
+}

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -8,7 +8,9 @@ import 'package:overlay_support/overlay_support.dart';
 
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
 import '../services/contact_database.dart';
+import '../services/reminder_notifications.dart';
 import '../widgets/system_notifications.dart';
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
@@ -51,6 +53,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   // --- keys для автоскролла к самим карточкам ---
   final _extraCardKey = GlobalKey();
+  final _remindersCardKey = GlobalKey();
   final _notesCardKey = GlobalKey();
 
   IconData _statusIcon(String s) {
@@ -62,6 +65,43 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       case 'Тёплый':     return Icons.local_fire_department;
       default:           return Icons.label_outline;
     }
+  }
+
+  Widget _reminderRow(Reminder reminder, {bool isLast = false}) {
+    final theme = Theme.of(context);
+    final hasNote = reminder.note != null && reminder.note!.trim().isNotEmpty;
+    return _sheetRow(
+      leading: const Icon(Icons.alarm_on_outlined),
+      right: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  hasNote ? reminder.note!.trim() : 'Напоминание',
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  _formatReminderDate(reminder.remindAt),
+                  style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () => _confirmDeleteReminder(reminder),
+            tooltip: 'Удалить',
+            icon: const Icon(Icons.delete_outline),
+          ),
+        ],
+      ),
+      isLast: isLast,
+    );
   }
 
   Widget _noteRow(Note note, {bool isLast = false}) {
@@ -504,7 +544,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   bool _extraExpanded = false; // «Дополнительно»
   bool _notesExpanded = true; // «Заметки» открыто
+  bool _remindersExpanded = true; // «Напоминания» открыто
   List<Note> _notes = [];
+  List<Reminder> _reminders = [];
 
   // FocusNodes — для подсветки/навигации
   final FocusNode _focusBirth = FocusNode(skipTraversal: true);
@@ -549,6 +591,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     _contact = widget.contact;
     _loadFromContact();
     _loadNotes();
+    _loadReminders();
     // чтобы превью обновлялось при каждом символе
     _phoneController.addListener(() => setState(() {}));
     _nameController.addListener(() => setState(() {}));
@@ -586,6 +629,12 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     if (mounted) setState(() => _notes = notes);
   }
 
+  Future<void> _loadReminders() async {
+    if (_contact.id == null) return;
+    final reminders = await ContactDatabase.instance.remindersByContact(_contact.id!);
+    if (mounted) setState(() => _reminders = reminders);
+  }
+
   Future<void> _addNote() async {
     if (_contact.id == null) return;
     final note = await Navigator.push<Note>(
@@ -598,6 +647,125 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       await _loadNotes();
       if (!mounted) return;
       showSuccessBanner('Заметка добавлена');
+    }
+  }
+
+  Future<void> _addReminder() async {
+    if (_contact.id == null) return;
+    final now = DateTime.now();
+
+    final date = await showDatePicker(
+      context: context,
+      initialDate: now,
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 365 * 3)),
+      helpText: 'Выберите дату напоминания',
+    );
+    if (date == null) return;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(now.add(const Duration(minutes: 5))),
+      helpText: 'Выберите время напоминания',
+    );
+    if (time == null) return;
+
+    final remindAt = DateTime(date.year, date.month, date.day, time.hour, time.minute);
+    if (remindAt.isBefore(DateTime.now())) {
+      showErrorBanner('Нельзя установить напоминание в прошлом времени');
+      return;
+    }
+
+    final noteController = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Напоминание на ${_formatReminderDate(remindAt)}'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Текст напоминания (необязательно):'),
+            const SizedBox(height: 12),
+            TextField(
+              controller: noteController,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                hintText: 'Например: перезвонить или написать сообщение',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Сохранить'),
+          ),
+        ],
+      ),
+    );
+    final noteText = noteController.text.trim();
+    noteController.dispose();
+    if (confirmed != true) return;
+
+    final reminder = Reminder(
+      contactId: _contact.id!,
+      remindAt: remindAt,
+      note: noteText.isEmpty ? null : noteText,
+      createdAt: DateTime.now(),
+    );
+
+    try {
+      final id = await ContactDatabase.instance.insertReminder(reminder);
+      final saved = reminder.copyWith(id: id);
+      final contactForReminder = _snapshot();
+      await ReminderNotifications.schedule(saved, contactForReminder);
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание добавлено');
+    } catch (e) {
+      showErrorBanner('Не удалось сохранить напоминание: $e');
+    }
+  }
+
+  Future<void> _deleteReminder(Reminder reminder) async {
+    if (reminder.id == null) return;
+    try {
+      await ContactDatabase.instance.deleteReminder(reminder.id!);
+      await ReminderNotifications.cancel(reminder);
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание удалено');
+    } catch (e) {
+      showErrorBanner('Не удалось удалить напоминание: $e');
+    }
+  }
+
+  Future<void> _confirmDeleteReminder(Reminder reminder) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: Text('Напоминание на ${_formatReminderDate(reminder.remindAt)} будет удалено.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      await _deleteReminder(reminder);
     }
   }
 
@@ -676,6 +844,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     if (last >= 2 && last <= 4) return '$age года';
     return '$age лет';
   }
+
+  String _formatReminderDate(DateTime dateTime) =>
+      DateFormat('d MMMM yyyy, HH:mm', 'ru').format(dateTime);
 
   String _initials(String name) {
     final parts = name.trim().split(RegExp(r'\s+')).where((e) => e.isNotEmpty).toList();
@@ -1072,8 +1243,11 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
     final db = ContactDatabase.instance;
 
-    // Удаляем контакт и забираем снапшот заметок для возможного Undo
-    final notesSnapshot = await db.deleteContactWithSnapshot(c.id!);
+    // Удаляем контакт и забираем снапшот заметок/напоминаний для возможного Undo
+    final snapshot = await db.deleteContactWithSnapshot(c.id!);
+    for (final reminder in snapshot.reminders) {
+      await ReminderNotifications.cancel(reminder);
+    }
 
     // Показываем баннер с Undo
     _undoBanner?.dismiss();
@@ -1084,14 +1258,20 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       icon: Icons.delete_outline,
       onUndo: () async {
         _undoBanner = null;
-        final newId = await db.restoreContactWithNotes(c.copyWith(id: null), notesSnapshot);
+        final base = c.copyWith(id: null);
+        final newId = await db.restoreContactWithSnapshot(base, snapshot);
+        final restored = c.copyWith(id: newId);
 
         // Сообщаем открытому списку: локально добавить и подсветить (без автоскролла)
         ContactListScreen.notifyRestoredIfMounted(c, newId);
+        final reminders = await db.remindersByContact(newId);
+        for (final reminder in reminders) {
+          await ReminderNotifications.schedule(reminder, restored);
+        }
         showSystemNotification(
-        'Контакт восстановлен',
-        style: SystemNotificationStyle.success,
-        iconOverride: Icons.undo,
+          'Контакт восстановлен',
+          style: SystemNotificationStyle.success,
+          iconOverride: Icons.undo,
         );
       },
     );
@@ -1609,6 +1789,70 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     // Соцсеть — верхний хинт показываем, если пусто
                     _socialPickerField(),
                   ],
+                ),
+              ),
+
+              // ===== Блок: Напоминания =====
+              KeyedSubtree(
+                key: _remindersCardKey,
+                child: _collapsibleSectionCard(
+                  title: 'Напоминания',
+                  expanded: _remindersExpanded,
+                  onChanged: (v) {
+                    setState(() => _remindersExpanded = v);
+                    if (v) _scrollToCard(_remindersCardKey);
+                  },
+                  headerActions: [
+                    IconButton(
+                      tooltip: 'Добавить напоминание',
+                      onPressed: _contact.id == null ? null : _addReminder,
+                      icon: const Icon(Icons.add_alert_outlined),
+                    ),
+                  ],
+                  children: _reminders.isEmpty
+                      ? [
+                          Card(
+                            elevation: 0,
+                            child: Padding(
+                              padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                              child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  const Icon(
+                                    Icons.alarm_on_outlined,
+                                    size: 48,
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Text(
+                                    'Нет напоминаний',
+                                    style: Theme.of(context).textTheme.titleMedium,
+                                    textAlign: TextAlign.center,
+                                  ),
+                                  const SizedBox(height: 24),
+                                  FilledButton.icon(
+                                    onPressed: _contact.id == null ? null : _addReminder,
+                                    icon: const Icon(Icons.add),
+                                    label: const Text('Добавить напоминание'),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ]
+                      : [
+                          Card(
+                            elevation: 0,
+                            child: Column(
+                              children: [
+                                for (var i = 0; i < _reminders.length; i++)
+                                  _reminderRow(
+                                    _reminders[i],
+                                    isLast: i == _reminders.length - 1,
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ],
                 ),
               ),
 

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -4,6 +4,17 @@ import 'package:path/path.dart' as p;
 import 'package:flutter/foundation.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
+import '../models/reminder.dart';
+
+class ContactCascadeSnapshot {
+  final List<Note> notes;
+  final List<Reminder> reminders;
+
+  const ContactCascadeSnapshot({
+    this.notes = const [],
+    this.reminders = const [],
+  });
+}
 
 class ContactDatabase {
   ContactDatabase._();
@@ -22,8 +33,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 2, чтобы сработала миграция с FK + CASCADE
-      version: 2,
+      // ВАЖНО: поднимаем версию до 3, чтобы сработали миграции с FK + CASCADE и напоминаниями
+      version: 3,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -61,10 +72,22 @@ class ContactDatabase {
           )
         ''');
 
+        await db.execute('''
+          CREATE TABLE reminders(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            contactId INTEGER NOT NULL,
+            remindAt INTEGER NOT NULL,
+            note TEXT,
+            createdAt INTEGER NOT NULL,
+            FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+          )
+        ''');
+
         // Полезные индексы
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_category_createdAt ON contacts(category, createdAt)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(name)');
         await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
+        await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
       },
 
       onUpgrade: (db, oldV, newV) async {
@@ -101,6 +124,20 @@ class ContactDatabase {
           await db.execute('CREATE INDEX IF NOT EXISTS idx_notes_contactId_createdAt ON notes(contactId, createdAt)');
 
           await db.execute('PRAGMA foreign_keys = ON'); // включаем обратно
+        }
+
+        if (oldV < 3) {
+          await db.execute('''
+            CREATE TABLE IF NOT EXISTS reminders(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              contactId INTEGER NOT NULL,
+              remindAt INTEGER NOT NULL,
+              note TEXT,
+              createdAt INTEGER NOT NULL,
+              FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
+            )
+          ''');
+          await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
         }
       },
     );
@@ -260,15 +297,54 @@ class ContactDatabase {
     return maps.map(Note.fromMap).toList();
   }
 
+  // ================= Reminders =================
+
+  Future<int> insertReminder(Reminder reminder) async {
+    final db = await database;
+    final id = await db.insert('reminders', _mapForInsert(reminder.toMap()));
+    _bumpRevision();
+    return id;
+  }
+
+  Future<int> updateReminder(Reminder reminder) async {
+    final db = await database;
+    final rows = await db.update(
+      'reminders',
+      reminder.toMap(),
+      where: 'id = ?',
+      whereArgs: [reminder.id],
+    );
+    _bumpRevision();
+    return rows;
+  }
+
+  Future<int> deleteReminder(int id) async {
+    final db = await database;
+    final rows = await db.delete('reminders', where: 'id = ?', whereArgs: [id]);
+    _bumpRevision();
+    return rows;
+  }
+
+  Future<List<Reminder>> remindersByContact(int contactId) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      where: 'contactId = ?',
+      whereArgs: [contactId],
+      orderBy: 'remindAt ASC',
+    );
+    return maps.map(Reminder.fromMap).toList();
+  }
+
   // ================= Helpers для Undo =================
 
-  /// Удаляет контакт (каскадно удаляются заметки) и возвращает снапшот заметок.
-  /// В UI можно сохранить возвращённый список для последующего Undo.
-  ///
+  /// Удаляет контакт (каскадно удаляются заметки и напоминания) и
+  /// возвращает их снапшот. В UI можно сохранить возвращённые данные для Undo.
   /// Операция обёрнута в транзакцию, чтобы снимок и удаление были атомарными.
-  Future<List<Note>> deleteContactWithSnapshot(int contactId) async {
+  Future<ContactCascadeSnapshot> deleteContactWithSnapshot(int contactId) async {
     final db = await database;
-    final snapshot = <Note>[];
+    final notes = <Note>[];
+    final reminders = <Reminder>[];
 
     await db.transaction((txn) async {
       final maps = await txn.query(
@@ -277,14 +353,22 @@ class ContactDatabase {
         whereArgs: [contactId],
         orderBy: 'createdAt DESC',
       );
-      snapshot.addAll(maps.map(Note.fromMap));
+      notes.addAll(maps.map(Note.fromMap));
 
-      // Удаляем контакт — FK каскадно удалит связанные заметки
+      final reminderMaps = await txn.query(
+        'reminders',
+        where: 'contactId = ?',
+        whereArgs: [contactId],
+        orderBy: 'remindAt ASC',
+      );
+      reminders.addAll(reminderMaps.map(Reminder.fromMap));
+
+      // Удаляем контакт — FK каскадно удалит связанные заметки и напоминания
       await txn.delete('contacts', where: 'id = ?', whereArgs: [contactId]);
     });
 
     _bumpRevision();
-    return snapshot;
+    return ContactCascadeSnapshot(notes: notes, reminders: reminders);
   }
 
   /// Восстанавливает контакт (получает НОВЫЙ id) и возвращает его.
@@ -295,9 +379,12 @@ class ContactDatabase {
     return newId;
   }
 
-  /// Восстанавливает контакт и ВСЕ его заметки за одну транзакцию.
+  /// Восстанавливает контакт и все его заметки/напоминания за одну транзакцию.
   /// Возвращает новый id контакта.
-  Future<int> restoreContactWithNotes(Contact contact, List<Note> notes) async {
+  Future<int> restoreContactWithSnapshot(
+    Contact contact,
+    ContactCascadeSnapshot snapshot,
+  ) async {
     final db = await database;
     int newContactId = 0;
 
@@ -306,13 +393,26 @@ class ContactDatabase {
       newContactId = await txn.insert('contacts', _mapForInsert(contact.toMap()));
 
       // Вставляем его заметки с новым contactId
-      for (final n in notes) {
+      for (final n in snapshot.notes) {
         final noteMap = _mapForInsert(n.copyWith(contactId: newContactId, id: null).toMap());
         await txn.insert('notes', noteMap);
+      }
+
+      for (final r in snapshot.reminders) {
+        final reminderMap =
+            _mapForInsert(r.copyWith(contactId: newContactId, id: null).toMap());
+        await txn.insert('reminders', reminderMap);
       }
     });
 
     _bumpRevision();
     return newContactId;
   }
+
+  /// Поддержка старого API: восстанавливает контакт и только заметки.
+  Future<int> restoreContactWithNotes(Contact contact, List<Note> notes) =>
+      restoreContactWithSnapshot(
+        contact,
+        ContactCascadeSnapshot(notes: notes),
+      );
 }

--- a/lib/services/push_notifications.dart
+++ b/lib/services/push_notifications.dart
@@ -203,8 +203,17 @@ class PushNotifications {
 
   }
 
-  static Future<void> cancel(int id) => _plugin.cancel(id);
+  static Future<void> cancel(int id) async {
+    await ensureInitialized();
+    try {
+      await _plugin.cancel(id);
+    } catch (e, s) {
+      if (kDebugMode) print('Failed to cancel notification: $e\n$s');
+    }
+  }
+
   static Future<void> cancelAll() => _plugin.cancelAll();
+
   static Future<List<PendingNotificationRequest>> pending() =>
       _plugin.pendingNotificationRequests();
 }

--- a/lib/services/reminder_notifications.dart
+++ b/lib/services/reminder_notifications.dart
@@ -1,0 +1,35 @@
+import 'package:intl/intl.dart';
+
+import '../models/contact.dart';
+import '../models/reminder.dart';
+import 'push_notifications.dart';
+
+class ReminderNotifications {
+  ReminderNotifications._();
+
+  static String _defaultBody(Reminder reminder, Contact contact) {
+    final formatter = DateFormat('d MMMM, HH:mm', 'ru');
+    final when = formatter.format(reminder.remindAt);
+    return 'Свяжитесь с ${contact.name} ($when)';
+  }
+
+  static Future<void> schedule(Reminder reminder, Contact contact) async {
+    if (reminder.id == null) return;
+    final body = (reminder.note != null && reminder.note!.trim().isNotEmpty)
+        ? reminder.note!.trim()
+        : _defaultBody(reminder, contact);
+
+    await PushNotifications.scheduleOneTime(
+      id: Reminder.notificationId(reminder.id!),
+      whenLocal: reminder.remindAt,
+      title: 'Напоминание: ${contact.name}',
+      body: body,
+      exact: true,
+    );
+  }
+
+  static Future<void> cancel(Reminder reminder) async {
+    if (reminder.id == null) return;
+    await PushNotifications.cancel(Reminder.notificationId(reminder.id!));
+  }
+}


### PR DESCRIPTION
## Summary
- add a persistent reminder model and notification helper for contacts
- extend the contact database schema and undo flow to include reminders
- update the contact details UI to manage reminders and keep notifications in sync

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d85ddc1f48832580072dc802c6d65e