### PR TITLE
Add reminder completion states and list screen

### DIFF
--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -4,6 +4,7 @@ class Reminder {
   final String text;
   final DateTime remindAt;
   final DateTime createdAt;
+  final DateTime? completedAt;
 
   const Reminder({
     this.id,
@@ -11,6 +12,7 @@ class Reminder {
     required this.text,
     required this.remindAt,
     required this.createdAt,
+    this.completedAt,
   });
 
   Reminder copyWith({
@@ -19,6 +21,7 @@ class Reminder {
     String? text,
     DateTime? remindAt,
     DateTime? createdAt,
+    Object? completedAt = _sentinel,
   }) =>
       Reminder(
         id: id ?? this.id,
@@ -26,6 +29,9 @@ class Reminder {
         text: text ?? this.text,
         remindAt: remindAt ?? this.remindAt,
         createdAt: createdAt ?? this.createdAt,
+        completedAt: completedAt == _sentinel
+            ? this.completedAt
+            : completedAt as DateTime?,
       );
 
   Map<String, Object?> toMap() => {
@@ -34,6 +40,7 @@ class Reminder {
         'text': text,
         'remindAt': remindAt.millisecondsSinceEpoch,
         'createdAt': createdAt.millisecondsSinceEpoch,
+        'completedAt': completedAt?.millisecondsSinceEpoch,
       };
 
   factory Reminder.fromMap(Map<String, Object?> map) => Reminder(
@@ -44,5 +51,10 @@ class Reminder {
             DateTime.fromMillisecondsSinceEpoch(map['remindAt'] as int),
         createdAt:
             DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+        completedAt: map['completedAt'] != null
+            ? DateTime.fromMillisecondsSinceEpoch(map['completedAt'] as int)
+            : null,
       );
 }
+
+const _sentinel = Object();

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -10,6 +10,7 @@ import 'package:overlay_support/overlay_support.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
 import '../models/reminder.dart';
+import 'reminders_list_screen.dart';
 import '../services/contact_database.dart';
 import '../services/push_notifications.dart';
 import '../widgets/system_notifications.dart';
@@ -641,8 +642,8 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   Future<void> _loadReminders() async {
     if (_contact.id == null) return;
-    final reminders =
-        await ContactDatabase.instance.remindersByContact(_contact.id!);
+    final reminders = await ContactDatabase.instance
+        .remindersByContact(_contact.id!, onlyActive: true);
     if (mounted) setState(() => _reminders = reminders);
   }
 
@@ -709,6 +710,17 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
         showErrorBanner('Не удалось сохранить напоминание: $e');
       }
     }
+  }
+
+  Future<void> _openRemindersList() async {
+    if (_contact.id == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => RemindersListScreen(contact: _contact),
+      ),
+    );
+    await _loadReminders();
   }
 
   Future<void> _editReminder(Reminder reminder) async {
@@ -1948,6 +1960,11 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     if (v) _scrollToCard(_remindersCardKey);
                   },
                   headerActions: [
+                    TextButton(
+                      onPressed:
+                          _contact.id == null ? null : _openRemindersList,
+                      child: const Text('Список напоминаний'),
+                    ),
                     IconButton(
                       tooltip: 'Добавить напоминание',
                       onPressed: _contact.id == null ? null : _addReminder,

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -524,7 +524,8 @@ class _ContactListScreenState extends State<ContactListScreen> {
           _restoreLocally(c.copyWith(id: newId), highlight: true);
 
           // Восстанавливаем запланированные уведомления для будущих напоминаний
-          final restoredReminders = await db.remindersByContact(newId);
+          final restoredReminders =
+              await db.remindersByContact(newId, onlyActive: true);
           for (final reminder in restoredReminders) {
             if (reminder.remindAt.isAfter(DateTime.now()) && reminder.id != null) {
               await PushNotifications.scheduleOneTime(

--- a/lib/screens/reminders_list_screen.dart
+++ b/lib/screens/reminders_list_screen.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/contact.dart';
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+import '../services/push_notifications.dart';
+
+class RemindersListScreen extends StatefulWidget {
+  final Contact contact;
+
+  const RemindersListScreen({super.key, required this.contact});
+
+  @override
+  State<RemindersListScreen> createState() => _RemindersListScreenState();
+}
+
+class _RemindersListScreenState extends State<RemindersListScreen> {
+  final _db = ContactDatabase.instance;
+  final _formatter = DateFormat('dd.MM.yyyy HH:mm');
+
+  List<Reminder> _active = const [];
+  List<Reminder> _completed = const [];
+  bool _loading = false;
+
+  late final VoidCallback _revisionListener;
+
+  @override
+  void initState() {
+    super.initState();
+    _revisionListener = _loadReminders;
+    _db.revision.addListener(_revisionListener);
+    _loadReminders();
+  }
+
+  @override
+  void dispose() {
+    _db.revision.removeListener(_revisionListener);
+    super.dispose();
+  }
+
+  Future<void> _loadReminders() async {
+    final contactId = widget.contact.id;
+    if (contactId == null) return;
+    setState(() => _loading = true);
+
+    final active =
+        await _db.remindersByContact(contactId, onlyActive: true);
+    final completed =
+        await _db.remindersByContact(contactId, onlyCompleted: true);
+
+    if (!mounted) return;
+    setState(() {
+      _active = active;
+      _completed = completed;
+      _loading = false;
+    });
+  }
+
+  Future<void> _setCompleted(Reminder reminder, bool completed) async {
+    if (reminder.id == null) return;
+
+    final updated = reminder.copyWith(
+      completedAt: completed ? DateTime.now() : null,
+    );
+
+    try {
+      await _db.updateReminder(updated);
+      if (completed) {
+        await PushNotifications.cancel(reminder.id!);
+      } else if (updated.remindAt.isAfter(DateTime.now())) {
+        await PushNotifications.scheduleOneTime(
+          id: updated.id!,
+          whenLocal: updated.remindAt,
+          title: 'Напоминание: ${widget.contact.name}',
+          body: updated.text,
+        );
+      }
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            completed
+                ? 'Напоминание отмечено как завершённое'
+                : 'Напоминание вновь активное',
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Не удалось обновить напоминание: $e'),
+        ),
+      );
+    }
+  }
+
+  Future<void> _deleteReminder(Reminder reminder) async {
+    final id = reminder.id;
+    if (id == null) return;
+
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: const Text('Напоминание будет удалено и уведомление отменено.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+
+    if (ok != true) return;
+
+    try {
+      await _db.deleteReminder(id);
+      await PushNotifications.cancel(id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Напоминание удалено')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Не удалось удалить напоминание: $e')),
+      );
+    }
+  }
+
+  Widget _buildEmptyState(String text) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          text,
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReminderTile(Reminder reminder, {required bool completed}) {
+    final theme = Theme.of(context);
+    final subtitle = completed
+        ? reminder.completedAt != null
+            ? 'Завершено: ${_formatter.format(reminder.completedAt!)}'
+            : 'Завершено'
+        : 'Запланировано на ${_formatter.format(reminder.remindAt)}';
+
+    return ListTile(
+      leading: Checkbox.adaptive(
+        value: completed,
+        onChanged: (value) => _setCompleted(reminder, value ?? false),
+      ),
+      title: Text(
+        reminder.text,
+        style: completed
+            ? theme.textTheme.titleMedium?.copyWith(
+                decoration: TextDecoration.lineThrough,
+                color: theme.hintColor,
+              )
+            : theme.textTheme.titleMedium,
+      ),
+      subtitle: Text(subtitle),
+      trailing: IconButton(
+        icon: const Icon(Icons.delete_outline),
+        tooltip: 'Удалить напоминание',
+        onPressed: () => _deleteReminder(reminder),
+      ),
+      onTap: () => _setCompleted(reminder, !completed),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasData = _active.isNotEmpty || _completed.isNotEmpty;
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('Напоминания — ${widget.contact.name}'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Активные'),
+              Tab(text: 'Завершённые'),
+            ],
+          ),
+        ),
+        body: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : TabBarView(
+                children: [
+                  _active.isEmpty
+                      ? _buildEmptyState('Нет активных напоминаний')
+                      : ListView.separated(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemBuilder: (context, index) => _buildReminderTile(
+                                _active[index],
+                                completed: false,
+                              ),
+                          separatorBuilder: (_, __) => const Divider(height: 0),
+                          itemCount: _active.length,
+                        ),
+                  _completed.isEmpty
+                      ? _buildEmptyState(hasData
+                          ? 'Завершённых напоминаний нет'
+                          : 'Нет завершённых напоминаний')
+                      : ListView.separated(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemBuilder: (context, index) => _buildReminderTile(
+                                _completed[index],
+                                completed: true,
+                              ),
+                          separatorBuilder: (_, __) => const Divider(height: 0),
+                          itemCount: _completed.length,
+                        ),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -23,8 +23,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 3, чтобы сработала миграция с FK + CASCADE и напоминаниями
-      version: 3,
+      // ВАЖНО: поднимаем версию до 4, чтобы сработала миграция с FK + CASCADE и напоминаниями
+      version: 4,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -73,6 +73,7 @@ class ContactDatabase {
             text TEXT NOT NULL,
             remindAt INTEGER NOT NULL,
             createdAt INTEGER NOT NULL,
+            completedAt INTEGER,
             FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
           )
         ''');
@@ -123,10 +124,15 @@ class ContactDatabase {
               text TEXT NOT NULL,
               remindAt INTEGER NOT NULL,
               createdAt INTEGER NOT NULL,
+              completedAt INTEGER,
               FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
             )
           ''');
           await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
+        }
+
+        if (oldV < 4) {
+          await db.execute('ALTER TABLE reminders ADD COLUMN completedAt INTEGER');
         }
       },
     );
@@ -314,13 +320,31 @@ class ContactDatabase {
     return rows;
   }
 
-  Future<List<Reminder>> remindersByContact(int contactId) async {
+  Future<List<Reminder>> remindersByContact(
+    int contactId, {
+    bool onlyActive = false,
+    bool onlyCompleted = false,
+  }) async {
+    assert(!(onlyActive && onlyCompleted),
+        'Нельзя одновременно запрашивать только активные и только завершённые напоминания');
     final db = await database;
+    final where = StringBuffer('contactId = ?');
+    final whereArgs = <Object?>[contactId];
+    var orderBy = 'remindAt ASC';
+
+    if (onlyActive) {
+      where.write(' AND completedAt IS NULL');
+      orderBy = 'remindAt ASC';
+    } else if (onlyCompleted) {
+      where.write(' AND completedAt IS NOT NULL');
+      orderBy = 'completedAt DESC';
+    }
+
     final maps = await db.query(
       'reminders',
-      where: 'contactId = ?',
-      whereArgs: [contactId],
-      orderBy: 'remindAt ASC',
+      where: where.toString(),
+      whereArgs: whereArgs,
+      orderBy: orderBy,
     );
     return maps.map(Reminder.fromMap).toList();
   }


### PR DESCRIPTION
## Summary
- add a completion timestamp to reminders and migrate the database schema
- show only active reminders on the contact details screen and link to a full reminders list
- implement a reminders list screen with active/completed tabs and controls for completing or deleting reminders

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da44baef5883289ed3c05841d099e6