### PR TITLE
Refine reminder filtering and editing

### DIFF
--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -4,6 +4,7 @@ class Reminder {
   final String text;
   final DateTime remindAt;
   final DateTime createdAt;
+  final DateTime? completedAt;
 
   const Reminder({
     this.id,
@@ -11,6 +12,7 @@ class Reminder {
     required this.text,
     required this.remindAt,
     required this.createdAt,
+    this.completedAt,
   });
 
   Reminder copyWith({
@@ -19,6 +21,7 @@ class Reminder {
     String? text,
     DateTime? remindAt,
     DateTime? createdAt,
+    Object? completedAt = _sentinel,
   }) =>
       Reminder(
         id: id ?? this.id,
@@ -26,6 +29,9 @@ class Reminder {
         text: text ?? this.text,
         remindAt: remindAt ?? this.remindAt,
         createdAt: createdAt ?? this.createdAt,
+        completedAt: completedAt == _sentinel
+            ? this.completedAt
+            : completedAt as DateTime?,
       );
 
   Map<String, Object?> toMap() => {
@@ -34,6 +40,7 @@ class Reminder {
         'text': text,
         'remindAt': remindAt.millisecondsSinceEpoch,
         'createdAt': createdAt.millisecondsSinceEpoch,
+        'completedAt': completedAt?.millisecondsSinceEpoch,
       };
 
   factory Reminder.fromMap(Map<String, Object?> map) => Reminder(
@@ -44,5 +51,10 @@ class Reminder {
             DateTime.fromMillisecondsSinceEpoch(map['remindAt'] as int),
         createdAt:
             DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+        completedAt: map['completedAt'] != null
+            ? DateTime.fromMillisecondsSinceEpoch(map['completedAt'] as int)
+            : null,
       );
 }
+
+const _sentinel = Object();

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -10,6 +10,7 @@ import 'package:overlay_support/overlay_support.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
 import '../models/reminder.dart';
+import 'reminders_list_screen.dart';
 import '../services/contact_database.dart';
 import '../services/push_notifications.dart';
 import '../widgets/system_notifications.dart';
@@ -641,8 +642,8 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   Future<void> _loadReminders() async {
     if (_contact.id == null) return;
-    final reminders =
-        await ContactDatabase.instance.remindersByContact(_contact.id!);
+    final reminders = await ContactDatabase.instance
+        .remindersByContact(_contact.id!, onlyActive: true);
     if (mounted) setState(() => _reminders = reminders);
   }
 
@@ -709,6 +710,17 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
         showErrorBanner('Не удалось сохранить напоминание: $e');
       }
     }
+  }
+
+  Future<void> _openRemindersList() async {
+    if (_contact.id == null) return;
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => RemindersListScreen(contact: _contact),
+      ),
+    );
+    await _loadReminders();
   }
 
   Future<void> _editReminder(Reminder reminder) async {
@@ -1948,10 +1960,10 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     if (v) _scrollToCard(_remindersCardKey);
                   },
                   headerActions: [
-                    IconButton(
-                      tooltip: 'Добавить напоминание',
-                      onPressed: _contact.id == null ? null : _addReminder,
-                      icon: const Icon(Icons.add_alert_outlined),
+                    TextButton(
+                      onPressed:
+                          _contact.id == null ? null : _openRemindersList,
+                      child: const Text('Список напоминаний'),
                     ),
                   ],
                   children: _reminders.isEmpty

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -524,7 +524,8 @@ class _ContactListScreenState extends State<ContactListScreen> {
           _restoreLocally(c.copyWith(id: newId), highlight: true);
 
           // Восстанавливаем запланированные уведомления для будущих напоминаний
-          final restoredReminders = await db.remindersByContact(newId);
+          final restoredReminders =
+              await db.remindersByContact(newId, onlyActive: true);
           for (final reminder in restoredReminders) {
             if (reminder.remindAt.isAfter(DateTime.now()) && reminder.id != null) {
               await PushNotifications.scheduleOneTime(

--- a/lib/screens/reminders_list_screen.dart
+++ b/lib/screens/reminders_list_screen.dart
@@ -1,0 +1,408 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/contact.dart';
+import '../models/reminder.dart';
+import '../services/contact_database.dart';
+import '../services/push_notifications.dart';
+
+class RemindersListScreen extends StatefulWidget {
+  final Contact contact;
+
+  const RemindersListScreen({super.key, required this.contact});
+
+  @override
+  State<RemindersListScreen> createState() => _RemindersListScreenState();
+}
+
+class _RemindersListScreenState extends State<RemindersListScreen> {
+  final _db = ContactDatabase.instance;
+  final _formatter = DateFormat('dd.MM.yyyy HH:mm');
+
+  List<Reminder> _active = const [];
+  List<Reminder> _completed = const [];
+  bool _loading = false;
+
+  late final VoidCallback _revisionListener;
+
+  @override
+  void initState() {
+    super.initState();
+    _revisionListener = _loadReminders;
+    _db.revision.addListener(_revisionListener);
+    _loadReminders();
+  }
+
+  @override
+  void dispose() {
+    _db.revision.removeListener(_revisionListener);
+    super.dispose();
+  }
+
+  Future<void> _loadReminders() async {
+    final contactId = widget.contact.id;
+    if (contactId == null) return;
+    setState(() => _loading = true);
+
+    final active =
+        await _db.remindersByContact(contactId, onlyActive: true);
+    final completed =
+        await _db.remindersByContact(contactId, onlyCompleted: true);
+
+    if (!mounted) return;
+    setState(() {
+      _active = active;
+      _completed = completed;
+      _loading = false;
+    });
+  }
+
+  Future<void> _setCompleted(Reminder reminder, bool completed) async {
+    if (reminder.id == null) return;
+
+    if (!completed) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Завершённое напоминание нельзя вернуть в активное'),
+        ),
+      );
+      return;
+    }
+
+    final updated = reminder.copyWith(completedAt: DateTime.now());
+
+    try {
+      await _db.updateReminder(updated);
+      await PushNotifications.cancel(reminder.id!);
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Напоминание отмечено как завершённое'),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Не удалось обновить напоминание: $e'),
+        ),
+      );
+    }
+  }
+
+  Future<void> _editReminder(Reminder reminder) async {
+    if (reminder.id == null) return;
+
+    final result = await _showReminderDialog(initial: reminder);
+    if (result == null) return;
+
+    final text = result.text.trim();
+    final when = result.when;
+    final isCompleted = reminder.completedAt != null;
+    if (!isCompleted && when.isBefore(DateTime.now())) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Выберите время в будущем')),
+      );
+      return;
+    }
+
+    final updated = reminder.copyWith(text: text, remindAt: when);
+
+    try {
+      await _db.updateReminder(updated);
+      if (!isCompleted) {
+        await PushNotifications.cancel(reminder.id!);
+        await PushNotifications.scheduleOneTime(
+          id: updated.id!,
+          whenLocal: updated.remindAt,
+          title: 'Напоминание: ${widget.contact.name}',
+          body: updated.text,
+        );
+      }
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Напоминание обновлено')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Не удалось обновить напоминание: $e')),
+      );
+    }
+  }
+
+  Future<void> _deleteReminder(Reminder reminder) async {
+    final id = reminder.id;
+    if (id == null) return;
+
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Удалить напоминание?'),
+        content: const Text('Напоминание будет удалено и уведомление отменено.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Удалить'),
+          ),
+        ],
+      ),
+    );
+
+    if (ok != true) return;
+
+    try {
+      await _db.deleteReminder(id);
+      await PushNotifications.cancel(id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Напоминание удалено')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Не удалось удалить напоминание: $e')),
+      );
+    }
+  }
+
+  Widget _buildEmptyState(String text) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(
+          text,
+          style: Theme.of(context).textTheme.bodyLarge,
+          textAlign: TextAlign.center,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReminderTile(Reminder reminder, {required bool completed}) {
+    final theme = Theme.of(context);
+    final subtitle = completed
+        ? reminder.completedAt != null
+            ? 'Завершено: ${_formatter.format(reminder.completedAt!)}'
+            : 'Завершено'
+        : 'Запланировано на ${_formatter.format(reminder.remindAt)}';
+
+    return ListTile(
+      leading: Checkbox.adaptive(
+        value: completed,
+        onChanged: completed
+            ? null
+            : (value) {
+                if (value == true) {
+                  _setCompleted(reminder, true);
+                }
+              },
+      ),
+      title: Text(
+        reminder.text,
+        style: completed
+            ? theme.textTheme.titleMedium?.copyWith(
+                decoration: TextDecoration.lineThrough,
+                color: theme.hintColor,
+              )
+            : theme.textTheme.titleMedium,
+      ),
+      subtitle: Text(subtitle),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.edit_outlined),
+            tooltip: 'Редактировать напоминание',
+            onPressed: () => _editReminder(reminder),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: 'Удалить напоминание',
+            onPressed: () => _deleteReminder(reminder),
+          ),
+        ],
+      ),
+      onTap: completed ? null : () => _setCompleted(reminder, true),
+    );
+  }
+
+  Future<({String text, DateTime when})?> _showReminderDialog({Reminder? initial}) async {
+    final controller = TextEditingController(text: initial?.text ?? '');
+    var selected = initial?.remindAt ?? DateTime.now().add(const Duration(minutes: 5));
+    final messenger = ScaffoldMessenger.of(context);
+
+    final result = await showDialog<({String text, DateTime when})>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            final dateLabel = DateFormat('dd.MM.yyyy HH:mm').format(selected);
+
+            return AlertDialog(
+              title: Text(initial == null ? 'Новое напоминание' : 'Редактирование напоминания'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: controller,
+                    minLines: 1,
+                    maxLines: null,
+                    autofocus: true,
+                    keyboardType: TextInputType.multiline,
+                    decoration: const InputDecoration(
+                      labelText: 'Текст напоминания',
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.event_outlined),
+                    title: Text(dateLabel),
+                    subtitle: const Text('Дата и время'),
+                    onTap: () async {
+                      final picked = await _pickReminderDateTime(selected);
+                      if (picked != null) {
+                        setState(() => selected = picked);
+                      }
+                    },
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Отмена'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    final text = controller.text.trim();
+                    if (text.isEmpty) {
+                      messenger.showSnackBar(
+                        const SnackBar(content: Text('Введите текст напоминания')),
+                      );
+                      return;
+                    }
+                    Navigator.pop(context, (text: text, when: selected));
+                  },
+                  child: const Text('Сохранить'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    return result;
+  }
+
+  Future<DateTime?> _pickReminderDateTime(DateTime initial) async {
+    final now = DateTime.now();
+    final minimumDate = initial.isBefore(now) ? initial : now;
+    var temp = initial;
+
+    return showModalBottomSheet<DateTime>(
+      context: context,
+      builder: (sheetContext) {
+        return SafeArea(
+          top: false,
+          child: SizedBox(
+            height: 300,
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(sheetContext),
+                        child: const Text('Отмена'),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.pop(sheetContext, temp),
+                        child: const Text('Готово'),
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(height: 0),
+                Expanded(
+                  child: CupertinoDatePicker(
+                    mode: CupertinoDatePickerMode.dateAndTime,
+                    use24hFormat: true,
+                    initialDateTime: initial,
+                    minimumDate: minimumDate,
+                    maximumDate: now.add(const Duration(days: 365 * 5)),
+                    onDateTimeChanged: (value) => temp = value,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasData = _active.isNotEmpty || _completed.isNotEmpty;
+
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text('Напоминания — ${widget.contact.name}'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Активные'),
+              Tab(text: 'Завершённые'),
+            ],
+          ),
+        ),
+        body: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : TabBarView(
+                children: [
+                  _active.isEmpty
+                      ? _buildEmptyState('Нет активных напоминаний')
+                      : ListView.separated(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemBuilder: (context, index) => _buildReminderTile(
+                                _active[index],
+                                completed: false,
+                              ),
+                          separatorBuilder: (_, __) => const Divider(height: 0),
+                          itemCount: _active.length,
+                        ),
+                  _completed.isEmpty
+                      ? _buildEmptyState(hasData
+                          ? 'Завершённых напоминаний нет'
+                          : 'Нет завершённых напоминаний')
+                      : ListView.separated(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemBuilder: (context, index) => _buildReminderTile(
+                                _completed[index],
+                                completed: true,
+                              ),
+                          separatorBuilder: (_, __) => const Divider(height: 0),
+                          itemCount: _completed.length,
+                        ),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -23,8 +23,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 3, чтобы сработала миграция с FK + CASCADE и напоминаниями
-      version: 3,
+      // ВАЖНО: поднимаем версию до 4, чтобы сработала миграция с FK + CASCADE и напоминаниями
+      version: 4,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -73,6 +73,7 @@ class ContactDatabase {
             text TEXT NOT NULL,
             remindAt INTEGER NOT NULL,
             createdAt INTEGER NOT NULL,
+            completedAt INTEGER,
             FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
           )
         ''');
@@ -123,10 +124,15 @@ class ContactDatabase {
               text TEXT NOT NULL,
               remindAt INTEGER NOT NULL,
               createdAt INTEGER NOT NULL,
+              completedAt INTEGER,
               FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
             )
           ''');
           await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
+        }
+
+        if (oldV < 4) {
+          await db.execute('ALTER TABLE reminders ADD COLUMN completedAt INTEGER');
         }
       },
     );
@@ -314,13 +320,35 @@ class ContactDatabase {
     return rows;
   }
 
-  Future<List<Reminder>> remindersByContact(int contactId) async {
+  Future<List<Reminder>> remindersByContact(
+    int contactId, {
+    bool onlyActive = false,
+    bool onlyCompleted = false,
+  }) async {
+    assert(!(onlyActive && onlyCompleted),
+        'Нельзя одновременно запрашивать только активные и только завершённые напоминания');
     final db = await database;
+    final where = StringBuffer('contactId = ?');
+    final whereArgs = <Object?>[contactId];
+    var orderBy = 'remindAt ASC';
+
+    if (onlyActive) {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      where
+        ..write(' AND completedAt IS NULL')
+        ..write(' AND remindAt >= ?');
+      whereArgs.add(now);
+      orderBy = 'remindAt ASC';
+    } else if (onlyCompleted) {
+      where.write(' AND completedAt IS NOT NULL');
+      orderBy = 'completedAt DESC';
+    }
+
     final maps = await db.query(
       'reminders',
-      where: 'contactId = ?',
-      whereArgs: [contactId],
-      orderBy: 'remindAt ASC',
+      where: where.toString(),
+      whereArgs: whereArgs,
+      orderBy: orderBy,
     );
     return maps.map(Reminder.fromMap).toList();
   }


### PR DESCRIPTION
## Summary
- treat active reminders as future events both in database queries and contact details view
- add editing actions to the reminders list, prevent returning completed reminders to active, and keep completion-only toggles
- simplify the contact details reminder header by removing the extra icon button

## Testing
- not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68da44baef5883289ed3c05841d099e6