### PR TITLE
Inline reminders management in contact details

### DIFF
--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -4,6 +4,7 @@ class Reminder {
   final String text;
   final DateTime remindAt;
   final DateTime createdAt;
+  final DateTime? completedAt;
 
   const Reminder({
     this.id,
@@ -11,6 +12,7 @@ class Reminder {
     required this.text,
     required this.remindAt,
     required this.createdAt,
+    this.completedAt,
   });
 
   Reminder copyWith({
@@ -19,6 +21,7 @@ class Reminder {
     String? text,
     DateTime? remindAt,
     DateTime? createdAt,
+    Object? completedAt = _sentinel,
   }) =>
       Reminder(
         id: id ?? this.id,
@@ -26,6 +29,9 @@ class Reminder {
         text: text ?? this.text,
         remindAt: remindAt ?? this.remindAt,
         createdAt: createdAt ?? this.createdAt,
+        completedAt: completedAt == _sentinel
+            ? this.completedAt
+            : completedAt as DateTime?,
       );
 
   Map<String, Object?> toMap() => {
@@ -34,6 +40,7 @@ class Reminder {
         'text': text,
         'remindAt': remindAt.millisecondsSinceEpoch,
         'createdAt': createdAt.millisecondsSinceEpoch,
+        'completedAt': completedAt?.millisecondsSinceEpoch,
       };
 
   factory Reminder.fromMap(Map<String, Object?> map) => Reminder(
@@ -44,5 +51,10 @@ class Reminder {
             DateTime.fromMillisecondsSinceEpoch(map['remindAt'] as int),
         createdAt:
             DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+        completedAt: map['completedAt'] != null
+            ? DateTime.fromMillisecondsSinceEpoch(map['completedAt'] as int)
+            : null,
       );
 }
+
+const _sentinel = Object();

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -68,41 +68,41 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     }
   }
 
-  Widget _reminderRow(Reminder reminder, {bool isLast = false}) {
+  Widget _reminderTile(Reminder reminder, {required bool completed}) {
     final theme = Theme.of(context);
-    final dateLabel = DateFormat('dd.MM.yyyy HH:mm').format(reminder.remindAt);
-    final isPast = reminder.remindAt.isBefore(DateTime.now());
+    final formatter = DateFormat('dd.MM.yyyy HH:mm');
+    final subtitle = completed
+        ? reminder.completedAt != null
+            ? 'Завершено: ${formatter.format(reminder.completedAt!)}'
+            : 'Завершено'
+        : 'Запланировано на ${formatter.format(reminder.remindAt)}';
 
-    return _sheetRow(
-      leading: const Icon(Icons.notifications_active_outlined),
-      right: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  reminder.text,
-                  softWrap: true,
-                  style: theme.textTheme.bodyLarge,
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  dateLabel,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: isPast
-                        ? theme.colorScheme.error
-                        : theme.hintColor,
-                  ),
-                ),
-              ],
+    final textStyle = completed
+        ? theme.textTheme.titleMedium?.copyWith(
+            decoration: TextDecoration.lineThrough,
+            color: theme.hintColor,
+          )
+        : theme.textTheme.titleMedium;
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      leading: completed
+          ? Icon(Icons.check_circle, color: theme.colorScheme.primary)
+          : IconButton(
+              icon: const Icon(Icons.check_circle_outline),
+              tooltip: 'Отметить выполненным',
+              color: theme.colorScheme.primary,
+              onPressed: () => _completeReminder(reminder),
             ),
-          ),
+      title: Text(reminder.text, style: textStyle),
+      subtitle: Text(subtitle),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
           IconButton(
             icon: const Icon(Icons.edit_outlined),
             tooltip: 'Редактировать напоминание',
-            onPressed: () => _editReminder(reminder),
+            onPressed: completed ? null : () => _editReminder(reminder),
           ),
           IconButton(
             icon: const Icon(Icons.delete_outline),
@@ -111,8 +111,6 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
           ),
         ],
       ),
-      onTap: () => _editReminder(reminder),
-      isLast: isLast,
     );
   }
 
@@ -560,7 +558,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   bool _extraExpanded = false; // «Дополнительно»
   bool _remindersExpanded = true; // «Напоминания» открыто
-  List<Reminder> _reminders = [];
+  List<Reminder> _activeReminders = [];
+  List<Reminder> _completedReminders = [];
+  int _selectedRemindersTab = 0;
   bool _notesExpanded = true; // «Заметки» открыто
   List<Note> _notes = [];
 
@@ -640,10 +640,28 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   }
 
   Future<void> _loadReminders() async {
-    if (_contact.id == null) return;
-    final reminders =
-        await ContactDatabase.instance.remindersByContact(_contact.id!);
-    if (mounted) setState(() => _reminders = reminders);
+    final contactId = _contact.id;
+    if (contactId == null) {
+      if (mounted) {
+        setState(() {
+          _activeReminders = [];
+          _completedReminders = [];
+        });
+      }
+      return;
+    }
+
+    final db = ContactDatabase.instance;
+    final active = await db.remindersByContact(contactId, onlyActive: true);
+    final completed =
+        await db.remindersByContact(contactId, onlyCompleted: true);
+
+    if (mounted) {
+      setState(() {
+        _activeReminders = active;
+        _completedReminders = completed;
+      });
+    }
   }
 
   Future<void> _loadNotes() async {
@@ -712,7 +730,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   }
 
   Future<void> _editReminder(Reminder reminder) async {
-    if (reminder.id == null) return;
+    if (reminder.id == null || reminder.completedAt != null) return;
 
     final result = await _showReminderDialog(initial: reminder);
     if (result == null) return;
@@ -742,6 +760,25 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     } catch (e) {
       if (mounted) {
         showErrorBanner('Не удалось обновить напоминание: $e');
+      }
+    }
+  }
+
+  Future<void> _completeReminder(Reminder reminder) async {
+    final reminderId = reminder.id;
+    if (reminderId == null || reminder.completedAt != null) return;
+
+    final updated = reminder.copyWith(completedAt: DateTime.now());
+
+    try {
+      await ContactDatabase.instance.updateReminder(updated);
+      await PushNotifications.cancel(reminderId);
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание завершено');
+    } catch (e) {
+      if (mounted) {
+        showErrorBanner('Не удалось завершить напоминание: $e');
       }
     }
   }
@@ -1947,70 +1984,122 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     setState(() => _remindersExpanded = v);
                     if (v) _scrollToCard(_remindersCardKey);
                   },
-                  headerActions: [
-                    IconButton(
-                      tooltip: 'Добавить напоминание',
-                      onPressed: _contact.id == null ? null : _addReminder,
-                      icon: const Icon(Icons.add_alert_outlined),
-                    ),
-                  ],
-                  children: _reminders.isEmpty
-                      ? [
-                          Card(
-                            elevation: 0,
-                            child: Padding(
-                              padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
-                              child: Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  const Icon(
-                                    Icons.notifications_active_outlined,
-                                    size: 48,
-                                  ),
-                                  const SizedBox(height: 12),
-                                  Text(
-                                    _contact.id == null
-                                        ? 'Сохраните контакт, чтобы добавлять напоминания'
-                                        : 'Нет напоминаний',
-                                    style: Theme.of(context).textTheme.titleMedium,
-                                    textAlign: TextAlign.center,
-                                  ),
-                                  const SizedBox(height: 24),
-                                  FilledButton.icon(
-                                    onPressed:
-                                        _contact.id == null ? null : _addReminder,
-                                    icon: const Icon(Icons.add),
-                                    label: const Text('Добавить напоминание'),
-                                  ),
-                                ],
+                  children: [
+                    if (_contact.id == null)
+                      Card(
+                        elevation: 0,
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(
+                                Icons.notifications_active_outlined,
+                                size: 48,
                               ),
-                            ),
+                              const SizedBox(height: 12),
+                              Text(
+                                'Сохраните контакт, чтобы добавлять напоминания',
+                                style: Theme.of(context).textTheme.titleMedium,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 24),
+                              FilledButton.icon(
+                                onPressed: null,
+                                icon: const Icon(Icons.add),
+                                label: const Text('Добавить напоминание'),
+                              ),
+                            ],
                           ),
-                        ]
-                      : [
-                          Card(
+                        ),
+                      )
+                    else ...[
+                      Center(
+                        child: ToggleButtons(
+                          isSelected: [
+                            _selectedRemindersTab == 0,
+                            _selectedRemindersTab == 1,
+                          ],
+                          borderRadius: BorderRadius.circular(20),
+                          constraints: const BoxConstraints(minHeight: 36, minWidth: 120),
+                          onPressed: (index) {
+                            setState(() => _selectedRemindersTab = index);
+                          },
+                          children: const [
+                            Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 12),
+                              child: Text('Активные'),
+                            ),
+                            Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 12),
+                              child: Text('Завершённые'),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Builder(
+                        builder: (context) {
+                          final isCompletedTab = _selectedRemindersTab == 1;
+                          final reminders =
+                              isCompletedTab ? _completedReminders : _activeReminders;
+                          final emptyText = isCompletedTab
+                              ? 'Нет завершённых напоминаний'
+                              : 'Нет активных напоминаний';
+
+                          if (reminders.isEmpty)
+                            return Card(
+                              elevation: 0,
+                              child: Padding(
+                                padding:
+                                    const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Icon(
+                                      Icons.notifications_active_outlined,
+                                      size: 48,
+                                    ),
+                                    const SizedBox(height: 12),
+                                    Text(
+                                      emptyText,
+                                      style:
+                                          Theme.of(context).textTheme.titleMedium,
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+
+                          return Card(
                             elevation: 0,
                             child: Column(
                               children: [
-                                for (var i = 0; i < _reminders.length; i++)
-                                  _reminderRow(
-                                    _reminders[i],
-                                    isLast: i == _reminders.length - 1,
+                                for (var i = 0; i < reminders.length; i++) ...[
+                                  _reminderTile(
+                                    reminders[i],
+                                    completed: isCompletedTab,
                                   ),
+                                  if (i != reminders.length - 1)
+                                    const Divider(height: 0),
+                                ],
                               ],
                             ),
-                          ),
-                          const SizedBox(height: 12),
-                          Align(
-                            alignment: Alignment.centerLeft,
-                            child: FilledButton.icon(
-                              onPressed:
-                                  _contact.id == null ? null : _addReminder,
-                              icon: const Icon(Icons.add),
-                              label: const Text('Добавить напоминание'),
-                            ),
-                          ),
-                        ],
+                          );
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: FilledButton.icon(
+                          onPressed: _addReminder,
+                          icon: const Icon(Icons.add),
+                          label: const Text('Добавить напоминание'),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
               ),
 

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -524,7 +524,8 @@ class _ContactListScreenState extends State<ContactListScreen> {
           _restoreLocally(c.copyWith(id: newId), highlight: true);
 
           // Восстанавливаем запланированные уведомления для будущих напоминаний
-          final restoredReminders = await db.remindersByContact(newId);
+          final restoredReminders =
+              await db.remindersByContact(newId, onlyActive: true);
           for (final reminder in restoredReminders) {
             if (reminder.remindAt.isAfter(DateTime.now()) && reminder.id != null) {
               await PushNotifications.scheduleOneTime(

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -23,8 +23,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 3, чтобы сработала миграция с FK + CASCADE и напоминаниями
-      version: 3,
+      // ВАЖНО: поднимаем версию до 4, чтобы сработала миграция с FK + CASCADE и напоминаниями
+      version: 4,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -73,6 +73,7 @@ class ContactDatabase {
             text TEXT NOT NULL,
             remindAt INTEGER NOT NULL,
             createdAt INTEGER NOT NULL,
+            completedAt INTEGER,
             FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
           )
         ''');
@@ -123,10 +124,15 @@ class ContactDatabase {
               text TEXT NOT NULL,
               remindAt INTEGER NOT NULL,
               createdAt INTEGER NOT NULL,
+              completedAt INTEGER,
               FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
             )
           ''');
           await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
+        }
+
+        if (oldV < 4) {
+          await db.execute('ALTER TABLE reminders ADD COLUMN completedAt INTEGER');
         }
       },
     );
@@ -314,13 +320,35 @@ class ContactDatabase {
     return rows;
   }
 
-  Future<List<Reminder>> remindersByContact(int contactId) async {
+  Future<List<Reminder>> remindersByContact(
+    int contactId, {
+    bool onlyActive = false,
+    bool onlyCompleted = false,
+  }) async {
+    assert(!(onlyActive && onlyCompleted),
+        'Нельзя одновременно запрашивать только активные и только завершённые напоминания');
     final db = await database;
+    final where = StringBuffer('contactId = ?');
+    final whereArgs = <Object?>[contactId];
+    var orderBy = 'remindAt ASC';
+
+    if (onlyActive) {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      where
+        ..write(' AND completedAt IS NULL')
+        ..write(' AND remindAt >= ?');
+      whereArgs.add(now);
+      orderBy = 'remindAt ASC';
+    } else if (onlyCompleted) {
+      where.write(' AND completedAt IS NOT NULL');
+      orderBy = 'completedAt DESC';
+    }
+
     final maps = await db.query(
       'reminders',
-      where: 'contactId = ?',
-      whereArgs: [contactId],
-      orderBy: 'remindAt ASC',
+      where: where.toString(),
+      whereArgs: whereArgs,
+      orderBy: orderBy,
     );
     return maps.map(Reminder.fromMap).toList();
   }


### PR DESCRIPTION
## Summary
- embed reminder tabs into the contact details screen, loading both active and completed reminders inline
- add a completion button, remove tap-to-edit, and block editing of completed reminders
- delete the standalone reminders list screen now that management happens inline

## Testing
- not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68da44baef5883289ed3c05841d099e6