### PR TITLE
Add global reminders overview screen

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,6 +10,7 @@ class App extends StatelessWidget {
   /// Глобальный ключ навигатора — доступен из любого места:
   /// App.navigatorKey.currentState?.push(...);
   static final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+  static final RouteObserver<ModalRoute<void>> routeObserver = RouteObserver<ModalRoute<void>>();
 
   @override
   Widget build(BuildContext context) {
@@ -18,6 +19,7 @@ class App extends StatelessWidget {
         title: 'Touch NoteBook',
         debugShowCheckedModeBanner: false, // 🔔 убирает "DEBUG" в углу
         navigatorKey: navigatorKey, // <-- ВАЖНО: подключили ключ
+        navigatorObservers: [routeObserver],
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(
             seedColor: Colors.deepPurple,

--- a/lib/models/contact.dart
+++ b/lib/models/contact.dart
@@ -1,4 +1,7 @@
 class Contact {
+  static const reminderTagName = 'Напоминания';
+  static const legacyReminderTagName = 'Напомнить';
+
   final int? id;
   final String name;
   final DateTime? birthDate;
@@ -13,6 +16,7 @@ class Contact {
   final List<String> tags;
   final String? comment;
   final DateTime createdAt;
+  final int activeReminderCount;
 
   const Contact({
     this.id,
@@ -29,23 +33,41 @@ class Contact {
     this.tags = const [],
     this.comment,
     required this.createdAt,
+    this.activeReminderCount = 0,
   });
 
-  Contact copyWith({int? id}) => Contact(
+  Contact copyWith({
+    int? id,
+    String? name,
+    DateTime? birthDate,
+    int? ageManual,
+    String? profession,
+    String? city,
+    String? phone,
+    String? email,
+    String? social,
+    String? category,
+    String? status,
+    List<String>? tags,
+    String? comment,
+    DateTime? createdAt,
+    int? activeReminderCount,
+  }) => Contact(
         id: id ?? this.id,
-        name: name,
-        birthDate: birthDate,
-        ageManual: ageManual,
-        profession: profession,
-        city: city,
-        phone: phone,
-        email: email,
-        social: social,
-        category: category,
-        status: status,
-        tags: tags,
-        comment: comment,
-        createdAt: createdAt,
+        name: name ?? this.name,
+        birthDate: birthDate ?? this.birthDate,
+        ageManual: ageManual ?? this.ageManual,
+        profession: profession ?? this.profession,
+        city: city ?? this.city,
+        phone: phone ?? this.phone,
+        email: email ?? this.email,
+        social: social ?? this.social,
+        category: category ?? this.category,
+        status: status ?? this.status,
+        tags: tags ?? this.tags,
+        comment: comment ?? this.comment,
+        createdAt: createdAt ?? this.createdAt,
+        activeReminderCount: activeReminderCount ?? this.activeReminderCount,
       );
 
   Map<String, dynamic> toMap() => {
@@ -79,8 +101,20 @@ class Contact {
         social: map['social'] as String?,
         category: map['category'] as String,
         status: map['status'] as String,
-        tags: (map['tags'] as String?)?.split(',').where((e) => e.isNotEmpty).toList() ?? [],
+        tags: (map['tags'] as String?)
+                ?.split(',')
+                .where((e) {
+                  if (e.isEmpty) return false;
+                  return e != reminderTagName && e != legacyReminderTagName;
+                })
+                .toList() ??
+            [],
         comment: map['comment'] as String?,
         createdAt: DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+        activeReminderCount: () {
+          final value = map['activeReminderCount'];
+          if (value is num) return value.toInt();
+          return 0;
+        }(),
       );
 }

--- a/lib/models/reminder.dart
+++ b/lib/models/reminder.dart
@@ -4,6 +4,7 @@ class Reminder {
   final String text;
   final DateTime remindAt;
   final DateTime createdAt;
+  final DateTime? completedAt;
 
   const Reminder({
     this.id,
@@ -11,6 +12,7 @@ class Reminder {
     required this.text,
     required this.remindAt,
     required this.createdAt,
+    this.completedAt,
   });
 
   Reminder copyWith({
@@ -19,6 +21,7 @@ class Reminder {
     String? text,
     DateTime? remindAt,
     DateTime? createdAt,
+    Object? completedAt = _sentinel,
   }) =>
       Reminder(
         id: id ?? this.id,
@@ -26,6 +29,9 @@ class Reminder {
         text: text ?? this.text,
         remindAt: remindAt ?? this.remindAt,
         createdAt: createdAt ?? this.createdAt,
+        completedAt: completedAt == _sentinel
+            ? this.completedAt
+            : completedAt as DateTime?,
       );
 
   Map<String, Object?> toMap() => {
@@ -34,6 +40,7 @@ class Reminder {
         'text': text,
         'remindAt': remindAt.millisecondsSinceEpoch,
         'createdAt': createdAt.millisecondsSinceEpoch,
+        'completedAt': completedAt?.millisecondsSinceEpoch,
       };
 
   factory Reminder.fromMap(Map<String, Object?> map) => Reminder(
@@ -44,5 +51,10 @@ class Reminder {
             DateTime.fromMillisecondsSinceEpoch(map['remindAt'] as int),
         createdAt:
             DateTime.fromMillisecondsSinceEpoch(map['createdAt'] as int),
+        completedAt: map['completedAt'] != null
+            ? DateTime.fromMillisecondsSinceEpoch(map['completedAt'] as int)
+            : null,
       );
 }
+
+const _sentinel = Object();

--- a/lib/models/reminder_with_contact_info.dart
+++ b/lib/models/reminder_with_contact_info.dart
@@ -1,0 +1,13 @@
+import 'reminder.dart';
+
+class ReminderWithContactInfo {
+  final Reminder reminder;
+  final String contactName;
+  final String contactCategory;
+
+  const ReminderWithContactInfo({
+    required this.reminder,
+    required this.contactName,
+    required this.contactCategory,
+  });
+}

--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -18,7 +18,7 @@ abstract class Dict {
     'Потенциальный': ['Холодный', 'Тёплый', 'Потерянный'],
   };
 
-  static const tags = ['Новый', 'Напомнить', 'VIP'];
+  static const tags = ['Новый', 'VIP'];
 }
 
 class AddContactScreen extends StatefulWidget {
@@ -147,7 +147,8 @@ class _AddContactScreenState extends State<AddContactScreen> {
     switch (tag) {
       case 'Новый':
         return Colors.white;
-      case 'Напомнить':
+      case Contact.reminderTagName:
+      case Contact.legacyReminderTagName:
         return Colors.purple;
       case 'VIP':
         return Colors.yellow;
@@ -161,7 +162,8 @@ class _AddContactScreenState extends State<AddContactScreen> {
       case 'Новый':
       case 'VIP':
         return Colors.black;
-      case 'Напомнить':
+      case Contact.reminderTagName:
+      case Contact.legacyReminderTagName:
         return Colors.white;
       default:
         return Colors.black;
@@ -743,6 +745,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       tags: _tags.toList(),
       comment: _commentController.text.trim().isNotEmpty ? _commentController.text.trim() : null,
       createdAt: _addedDate,
+      activeReminderCount: 0,
     );
 
     try {

--- a/lib/screens/all_reminders_screen.dart
+++ b/lib/screens/all_reminders_screen.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/reminder.dart';
+import '../models/reminder_with_contact_info.dart';
+import '../services/contact_database.dart';
+
+class AllRemindersScreen extends StatefulWidget {
+  const AllRemindersScreen({super.key});
+
+  @override
+  State<AllRemindersScreen> createState() => _AllRemindersScreenState();
+}
+
+class _AllRemindersScreenState extends State<AllRemindersScreen> {
+  final _db = ContactDatabase.instance;
+  late final VoidCallback _revisionListener;
+
+  bool _loading = true;
+  Object? _error;
+  List<_ReminderGroup> _groups = const [];
+
+  @override
+  void initState() {
+    super.initState();
+    _revisionListener = () => _load(showSpinner: false);
+    _db.revision.addListener(_revisionListener);
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _db.revision.removeListener(_revisionListener);
+    super.dispose();
+  }
+
+  Future<void> _load({bool showSpinner = true}) async {
+    if (showSpinner) {
+      setState(() {
+        _loading = true;
+        _error = null;
+      });
+    }
+
+    try {
+      final reminders = await _db.remindersWithContactInfo();
+      final groups = _groupByDate(reminders);
+      if (!mounted) return;
+      setState(() {
+        _groups = groups;
+        _loading = false;
+        _error = null;
+      });
+    } catch (error, stackTrace) {
+      debugPrint('Failed to load reminders: $error\n$stackTrace');
+      if (!mounted) return;
+      setState(() {
+        _error = error;
+        _loading = false;
+      });
+    }
+  }
+
+  List<_ReminderGroup> _groupByDate(List<ReminderWithContactInfo> reminders) {
+    if (reminders.isEmpty) return const [];
+
+    final sorted = reminders.toList()
+      ..sort((a, b) {
+        final dateA = DateUtils.dateOnly(a.reminder.remindAt);
+        final dateB = DateUtils.dateOnly(b.reminder.remindAt);
+        final cmp = dateA.compareTo(dateB);
+        if (cmp != 0) return cmp;
+        return a.reminder.remindAt.compareTo(b.reminder.remindAt);
+      });
+
+    final groups = <_ReminderGroup>[];
+    DateTime? currentDate;
+    var bucket = <ReminderWithContactInfo>[];
+
+    for (final entry in sorted) {
+      final date = DateUtils.dateOnly(entry.reminder.remindAt);
+      if (currentDate == null || date != currentDate) {
+        if (currentDate != null && bucket.isNotEmpty) {
+          groups.add(
+            _ReminderGroup(date: currentDate, reminders: List.unmodifiable(bucket)),
+          );
+          bucket = <ReminderWithContactInfo>[];
+        }
+        currentDate = date;
+      }
+      bucket.add(entry);
+    }
+
+    if (currentDate != null && bucket.isNotEmpty) {
+      groups.add(
+        _ReminderGroup(date: currentDate, reminders: List.unmodifiable(bucket)),
+      );
+    }
+
+    return List.unmodifiable(groups);
+  }
+
+  Future<void> _onRefresh() => _load(showSpinner: false);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Все напоминания'),
+      ),
+      body: _buildBody(context),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.error_outline, size: 40),
+              const SizedBox(height: 12),
+              const Text(
+                'Не удалось загрузить напоминания',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              FilledButton(
+                onPressed: _load,
+                child: const Text('Повторить'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_groups.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _onRefresh,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.symmetric(vertical: 120),
+          children: const [
+            Center(child: Icon(Icons.notifications_off_outlined, size: 40)),
+            SizedBox(height: 12),
+            Center(child: Text('Напоминаний пока нет')),
+          ],
+        ),
+      );
+    }
+
+    final theme = Theme.of(context);
+    final dateFormatter = DateFormat.yMMMMd('ru');
+    final timeFormatter = DateFormat('HH:mm', 'ru');
+    final completedFormatter = DateFormat('d MMMM, HH:mm', 'ru');
+
+    return RefreshIndicator(
+      onRefresh: _onRefresh,
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          for (final group in _groups) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+              child: Text(
+                toBeginningOfSentenceCase(dateFormatter.format(group.date)) ??
+                    dateFormatter.format(group.date),
+                style: theme.textTheme.titleMedium,
+              ),
+            ),
+            for (final item in group.reminders)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                child: Card(
+                  child: ListTile(
+                    leading: _ReminderStatusIcon(reminder: item.reminder),
+                    title: Text(item.reminder.text),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(item.contactName),
+                        const SizedBox(height: 4),
+                        Text(
+                          '${timeFormatter.format(item.reminder.remindAt)} • ${item.contactCategory}',
+                        ),
+                        if (item.reminder.completedAt != null) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            'Завершено: ${completedFormatter.format(item.reminder.completedAt!)}',
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+          ],
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReminderGroup {
+  final DateTime date;
+  final List<ReminderWithContactInfo> reminders;
+
+  const _ReminderGroup({required this.date, required this.reminders});
+}
+
+class _ReminderStatusIcon extends StatelessWidget {
+  const _ReminderStatusIcon({required this.reminder});
+
+  final Reminder reminder;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final isCompleted = reminder.completedAt != null;
+    final now = DateTime.now();
+    final isOverdue = !isCompleted && reminder.remindAt.isBefore(now);
+
+    late final IconData icon;
+    late final Color color;
+
+    if (isCompleted) {
+      icon = Icons.check_circle;
+      color = scheme.secondary;
+    } else if (isOverdue) {
+      icon = Icons.notification_important_outlined;
+      color = scheme.error;
+    } else {
+      icon = Icons.notifications_active_outlined;
+      color = scheme.primary;
+    }
+
+    return Icon(icon, color: color);
+  }
+}

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:characters/characters.dart';
 import 'package:overlay_support/overlay_support.dart';
 
+import '../app.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
 import '../models/reminder.dart';
@@ -25,7 +26,9 @@ class ContactDetailsScreen extends StatefulWidget {
   State<ContactDetailsScreen> createState() => _ContactDetailsScreenState();
 }
 
-class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
+enum _ReminderAction { complete, edit, delete }
+
+class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteAware {
   bool _isEditing = false;          // режим редактирования
   late Contact _contact;            // последний сохранённый снимок
 
@@ -51,6 +54,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   final _statusController = TextEditingController();
   final _commentController = TextEditingController();
   final _addedController = TextEditingController();
+  final _reminderTextController = TextEditingController();
 
   // --- keys для автоскролла к самим карточкам ---
   final _extraCardKey = GlobalKey();
@@ -68,51 +72,119 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     }
   }
 
-  Widget _reminderRow(Reminder reminder, {bool isLast = false}) {
+  Widget _reminderTagChip(int count) {
     final theme = Theme.of(context);
-    final dateLabel = DateFormat('dd.MM.yyyy HH:mm').format(reminder.remindAt);
-    final isPast = reminder.remindAt.isBefore(DateTime.now());
-
-    return _sheetRow(
-      leading: const Icon(Icons.notifications_active_outlined),
-      right: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    return Chip(
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  reminder.text,
-                  softWrap: true,
-                  style: theme.textTheme.bodyLarge,
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  dateLabel,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: isPast
-                        ? theme.colorScheme.error
-                        : theme.hintColor,
-                  ),
-                ),
-              ],
+          Text(
+            Contact.reminderTagName,
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontSize: 10,
+              color: _tagTextColor(Contact.reminderTagName),
             ),
           ),
-          IconButton(
-            icon: const Icon(Icons.edit_outlined),
-            tooltip: 'Редактировать напоминание',
-            onPressed: () => _editReminder(reminder),
-          ),
-          IconButton(
-            icon: const Icon(Icons.delete_outline),
-            tooltip: 'Удалить напоминание',
-            onPressed: () => _confirmDeleteReminder(reminder),
+          const SizedBox(width: 6),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              '$count',
+              style: theme.textTheme.bodySmall?.copyWith(
+                fontSize: 10,
+                color: _tagColor(Contact.reminderTagName),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
           ),
         ],
       ),
-      onTap: () => _editReminder(reminder),
-      isLast: isLast,
+      backgroundColor: _tagColor(Contact.reminderTagName),
+      visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 0),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+    );
+  }
+
+  Widget _reminderTile(Reminder reminder, {required bool completed}) {
+    final theme = Theme.of(context);
+    final formatter = DateFormat('dd.MM.yyyy HH:mm');
+    final subtitle = completed
+        ? reminder.completedAt != null
+            ? 'Завершено: ${formatter.format(reminder.completedAt!)}'
+            : 'Завершено'
+        : 'Запланировано на ${formatter.format(reminder.remindAt)}';
+
+    PopupMenuItem<_ReminderAction> buildMenuItem(
+      _ReminderAction action,
+      IconData icon,
+      String label,
+    ) {
+      return PopupMenuItem<_ReminderAction>(
+        value: action,
+        child: Row(
+          children: [
+            Icon(icon, size: 20),
+            const SizedBox(width: 12),
+            Flexible(child: Text(label)),
+          ],
+        ),
+      );
+    }
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      leading: Icon(
+        completed ? Icons.check_circle : Icons.notifications_outlined,
+        color: theme.colorScheme.primary,
+      ),
+      title: Text(reminder.text, style: theme.textTheme.titleMedium),
+      subtitle: Text(subtitle),
+      trailing: completed
+          ? IconButton(
+              tooltip: 'Удалить',
+              icon: const Icon(Icons.delete_outline),
+              onPressed: () => _confirmDeleteReminder(reminder),
+            )
+          : PopupMenuButton<_ReminderAction>(
+              tooltip: 'Действия',
+              icon: const Icon(Icons.more_vert),
+              onSelected: (action) {
+                switch (action) {
+                  case _ReminderAction.complete:
+                    _completeReminder(reminder);
+                    break;
+                  case _ReminderAction.edit:
+                    _editReminder(reminder);
+                    break;
+                  case _ReminderAction.delete:
+                    _confirmDeleteReminder(reminder);
+                    break;
+                }
+              },
+              itemBuilder: (context) => [
+                buildMenuItem(
+                  _ReminderAction.complete,
+                  Icons.check_circle_outline,
+                  'Отметить выполненным',
+                ),
+                buildMenuItem(
+                  _ReminderAction.edit,
+                  Icons.edit_outlined,
+                  'Редактировать',
+                ),
+                buildMenuItem(
+                  _ReminderAction.delete,
+                  Icons.delete_outline,
+                  'Удалить',
+                ),
+              ],
+            ),
     );
   }
 
@@ -372,7 +444,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   Color _tagColor(String tag) {
     switch (tag) {
       case 'Новый': return Colors.white;
-      case 'Напомнить': return Colors.purple;
+      case Contact.reminderTagName:
+      case Contact.legacyReminderTagName:
+        return Colors.purple;
       case 'VIP': return Colors.yellow;
       default: return Colors.grey.shade200;
     }
@@ -381,7 +455,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   Color _tagTextColor(String tag) {
     switch (tag) {
       case 'Новый': return Colors.black;
-      case 'Напомнить': return Colors.white;
+      case Contact.reminderTagName:
+      case Contact.legacyReminderTagName:
+        return Colors.white;
       case 'VIP': return Colors.black;
       default: return Colors.black;
     }
@@ -429,6 +505,8 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     // <<< статус с плейсхолдером "Статус"
     final statusText = _statusOrPlaceholder();
     final tags = _tags.toList();
+    final reminderCount = _activeReminders.length;
+    final showReminderTag = reminderCount > 0;
 
     Widget avatar() {
       final bg = _avatarBgFor(name, scheme);
@@ -492,7 +570,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 8),
-                  if (tags.isNotEmpty)
+                  if (tags.isNotEmpty || showReminderTag)
                     Wrap(
                       spacing: 4,
                       runSpacing: 4,
@@ -512,6 +590,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 0),
                             shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
                           ),
+                        if (showReminderTag) _reminderTagChip(reminderCount),
                       ],
                     ),
                 ],
@@ -560,7 +639,11 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
 
   bool _extraExpanded = false; // «Дополнительно»
   bool _remindersExpanded = true; // «Напоминания» открыто
-  List<Reminder> _reminders = [];
+  bool _routeSubscribed = false;
+  List<Reminder> _activeReminders = [];
+  List<Reminder> _completedReminders = [];
+  int _selectedRemindersTab = 0;
+  Timer? _remindersRefreshTimer;
   bool _notesExpanded = true; // «Заметки» открыто
   List<Note> _notes = [];
 
@@ -604,7 +687,13 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   @override
   void initState() {
     super.initState();
-    _contact = widget.contact;
+    _contact = widget.contact.copyWith(
+      tags: widget.contact.tags
+          .where((tag) =>
+              tag != Contact.reminderTagName &&
+              tag != Contact.legacyReminderTagName)
+          .toList(),
+    );
     _loadFromContact();
     _loadReminders();
     _loadNotes();
@@ -615,7 +704,24 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_routeSubscribed) {
+      final route = ModalRoute.of(context);
+      if (route is PageRoute) {
+        App.routeObserver.subscribe(this, route);
+        _routeSubscribed = true;
+      }
+    }
+  }
+
+  @override
   void dispose() {
+    if (_routeSubscribed) {
+      App.routeObserver.unsubscribe(this);
+      _routeSubscribed = false;
+    }
+    _remindersRefreshTimer?.cancel();
     _scroll.dispose();
     _nameController.dispose();
     _birthController.dispose();
@@ -628,6 +734,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     _statusController.dispose();
     _commentController.dispose();
     _addedController.dispose();
+    _reminderTextController.dispose();
 
     _focusBirth.dispose();
     _focusSocial.dispose();
@@ -639,11 +746,75 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     super.dispose();
   }
 
+  @override
+  void didPopNext() {
+    _loadReminders();
+  }
+
   Future<void> _loadReminders() async {
-    if (_contact.id == null) return;
-    final reminders =
-        await ContactDatabase.instance.remindersByContact(_contact.id!);
-    if (mounted) setState(() => _reminders = reminders);
+    final contactId = _contact.id;
+    if (contactId == null) {
+      if (mounted) {
+        setState(() {
+          _activeReminders = [];
+          _completedReminders = [];
+        });
+      }
+      _remindersRefreshTimer?.cancel();
+      return;
+    }
+
+    final db = ContactDatabase.instance;
+    final newlyCompleted =
+        await db.completeDueRemindersForContact(contactId);
+
+    if (newlyCompleted.isNotEmpty) {
+      await Future.wait([
+        for (final reminder in newlyCompleted)
+          if (reminder.id != null) PushNotifications.cancel(reminder.id!)
+      ]);
+    }
+
+    final active = await db.remindersByContact(contactId, onlyActive: true);
+    final completed =
+        await db.remindersByContact(contactId, onlyCompleted: true);
+
+    if (mounted) {
+      setState(() {
+        _activeReminders = active;
+        _completedReminders = completed;
+        _contact = _contact.copyWith(activeReminderCount: active.length);
+      });
+      _scheduleNextReminderRefresh();
+    }
+  }
+
+  void _scheduleNextReminderRefresh() {
+    _remindersRefreshTimer?.cancel();
+
+    if (_activeReminders.isEmpty) {
+      return;
+    }
+
+    final now = DateTime.now();
+    final upcoming = _activeReminders
+        .map((reminder) => reminder.remindAt)
+        .where((time) => time.isAfter(now))
+        .toList();
+
+    if (upcoming.isEmpty) {
+      return;
+    }
+
+    upcoming.sort();
+    var delay = upcoming.first.difference(now);
+    if (delay.isNegative) delay = Duration.zero;
+
+    _remindersRefreshTimer = Timer(delay + const Duration(seconds: 1), () {
+      if (mounted) {
+        _loadReminders();
+      }
+    });
   }
 
   Future<void> _loadNotes() async {
@@ -673,7 +844,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
       return;
     }
 
-    final result = await _showReminderDialog();
+    final result = await _showReminderSheet();
     if (result == null) return;
 
     final text = result.text.trim();
@@ -712,9 +883,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   }
 
   Future<void> _editReminder(Reminder reminder) async {
-    if (reminder.id == null) return;
+    if (reminder.id == null || reminder.completedAt != null) return;
 
-    final result = await _showReminderDialog(initial: reminder);
+    final result = await _showReminderSheet(initial: reminder);
     if (result == null) return;
 
     final text = result.text.trim();
@@ -742,6 +913,45 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     } catch (e) {
       if (mounted) {
         showErrorBanner('Не удалось обновить напоминание: $e');
+      }
+    }
+  }
+
+  Future<void> _completeReminder(Reminder reminder) async {
+    final reminderId = reminder.id;
+    if (reminderId == null || reminder.completedAt != null) return;
+
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Завершить напоминание?'),
+        content: const Text('Напоминание будет отмечено как выполненное и уведомление отменится.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Завершить'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm != true) return;
+
+    final updated = reminder.copyWith(completedAt: DateTime.now());
+
+    try {
+      await ContactDatabase.instance.updateReminder(updated);
+      await PushNotifications.cancel(reminderId);
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Напоминание завершено');
+    } catch (e) {
+      if (mounted) {
+        showErrorBanner('Не удалось завершить напоминание: $e');
       }
     }
   }
@@ -782,121 +992,144 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     }
   }
 
-  Future<({String text, DateTime when})?> _showReminderDialog({Reminder? initial}) async {
-    final controller = TextEditingController(text: initial?.text ?? '');
-    var selected = initial?.remindAt ?? DateTime.now().add(const Duration(minutes: 5));
+  Future<void> _clearCompletedReminders() async {
+    final contactId = _contact.id;
+    if (contactId == null) return;
 
-    final result = await showDialog<({String text, DateTime when})>(
+    final confirm = await showDialog<bool>(
       context: context,
-      builder: (context) {
+      builder: (context) => AlertDialog(
+        title: const Text('Очистить завершённые?'),
+        content: const Text('Все завершённые напоминания будут безвозвратно удалены.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Отмена'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Очистить'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm != true) return;
+
+    try {
+      await ContactDatabase.instance
+          .deleteCompletedRemindersForContact(contactId);
+      await _loadReminders();
+      if (!mounted) return;
+      showSuccessBanner('Завершённые напоминания удалены');
+    } catch (e) {
+      if (mounted) {
+        showErrorBanner('Не удалось очистить напоминания: $e');
+      }
+    }
+  }
+
+  Future<({String text, DateTime when})?> _showReminderSheet({Reminder? initial}) async {
+    final controller = _reminderTextController;
+    controller
+      ..text = initial?.text ?? ''
+      ..selection = TextSelection.fromPosition(
+        TextPosition(offset: controller.text.length),
+      );
+
+    var selected = initial?.remindAt ?? DateTime.now().add(const Duration(minutes: 5));
+    final now = DateTime.now();
+
+    final result = await showModalBottomSheet<({String text, DateTime when})>(
+      context: context,
+      isScrollControlled: true,
+      builder: (sheetContext) {
         return StatefulBuilder(
           builder: (context, setState) {
-            final dateLabel = DateFormat('dd.MM.yyyy HH:mm').format(selected);
+            final viewInsets = MediaQuery.of(context).viewInsets;
+            final minimumDate = selected.isBefore(now) ? selected : now;
 
-            return AlertDialog(
-              title: Text(initial == null ? 'Новое напоминание' : 'Редактирование напоминания'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  TextField(
-                    controller: controller,
-                    minLines: 1,
-                    maxLines: null,
-                    autofocus: true,
-                    keyboardType: TextInputType.multiline,
-                    decoration: const InputDecoration(
-                      labelText: 'Текст напоминания',
-                    ),
+            return AnimatedPadding(
+              duration: const Duration(milliseconds: 150),
+              curve: Curves.easeOut,
+              padding: EdgeInsets.only(bottom: viewInsets.bottom),
+              child: SafeArea(
+                top: false,
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.only(bottom: 16),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                initial == null
+                                    ? 'Новое напоминание'
+                                    : 'Редактирование напоминания',
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(sheetContext),
+                              child: const Text('Отмена'),
+                            ),
+                            const SizedBox(width: 8),
+                            FilledButton(
+                              onPressed: () {
+                                final text = controller.text.trim();
+                                if (text.isEmpty) {
+                                  showErrorBanner('Введите текст напоминания');
+                                  return;
+                                }
+                                Navigator.pop(sheetContext, (text: text, when: selected));
+                              },
+                              child: const Text('Сохранить'),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const Divider(height: 0),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                        child: TextField(
+                          controller: controller,
+                          minLines: 1,
+                          maxLines: null,
+                          autofocus: true,
+                          keyboardType: TextInputType.multiline,
+                          decoration: const InputDecoration(
+                            labelText: 'Текст напоминания',
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      SizedBox(
+                        height: 220,
+                        child: CupertinoDatePicker(
+                          mode: CupertinoDatePickerMode.dateAndTime,
+                          use24hFormat: true,
+                          initialDateTime: selected,
+                          minimumDate: minimumDate,
+                          maximumDate: now.add(const Duration(days: 365 * 5)),
+                          onDateTimeChanged: (value) => setState(() => selected = value),
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(height: 16),
-                  ListTile(
-                    contentPadding: EdgeInsets.zero,
-                    leading: const Icon(Icons.event_outlined),
-                    title: Text(dateLabel),
-                    subtitle: const Text('Дата и время'),
-                    onTap: () async {
-                      final picked = await _pickReminderDateTime(selected);
-                      if (picked != null) {
-                        setState(() => selected = picked);
-                      }
-                    },
-                  ),
-                ],
+                ),
               ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text('Отмена'),
-                ),
-                TextButton(
-                  onPressed: () {
-                    final text = controller.text.trim();
-                    if (text.isEmpty) {
-                      showErrorBanner('Введите текст напоминания');
-                      return;
-                    }
-                    Navigator.pop(context, (text: text, when: selected));
-                  },
-                  child: const Text('Сохранить'),
-                ),
-              ],
             );
           },
         );
       },
     );
 
+    controller.clear();
     return result;
-  }
-
-  Future<DateTime?> _pickReminderDateTime(DateTime initial) async {
-    final now = DateTime.now();
-    final minimumDate = initial.isBefore(now) ? initial : now;
-    var temp = initial;
-
-    return showModalBottomSheet<DateTime>(
-      context: context,
-      builder: (sheetContext) {
-        return SafeArea(
-          top: false,
-          child: SizedBox(
-            height: 300,
-            child: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(sheetContext),
-                        child: const Text('Отмена'),
-                      ),
-                      TextButton(
-                        onPressed: () => Navigator.pop(sheetContext, temp),
-                        child: const Text('Готово'),
-                      ),
-                    ],
-                  ),
-                ),
-                const Divider(height: 0),
-                Expanded(
-                  child: CupertinoDatePicker(
-                    mode: CupertinoDatePickerMode.dateAndTime,
-                    use24hFormat: true,
-                    initialDateTime: initial,
-                    minimumDate: minimumDate,
-                    maximumDate: now.add(const Duration(days: 365 * 5)),
-                    onDateTimeChanged: (value) => temp = value,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
   }
 
   // ==================== helpers ====================
@@ -915,9 +1148,14 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     social: _socialType,
     category: _category ?? _categoryController.text.trim(),
     status: _status ?? _statusController.text.trim(),
-    tags: _tags.toList(),
+    tags: _tags
+        .where((tag) =>
+            tag != Contact.reminderTagName &&
+            tag != Contact.legacyReminderTagName)
+        .toList(),
     comment: _commentController.text.trim().isNotEmpty ? _commentController.text.trim() : null,
     createdAt: _addedDate,
+    activeReminderCount: _contact.activeReminderCount,
   );
 
   bool _listEq(List<String> a, List<String> b) {
@@ -1668,24 +1906,6 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    Widget tagChip(String label) {
-      final selected = _tags.contains(label);
-      return ChoiceChip(
-        label: Text(label),
-        selected: selected,
-        onSelected: (v) {
-          setState(() {
-            if (v) {
-              _tags.add(label);
-            } else {
-              _tags.remove(label);
-            }
-            _updateEditingFromDirty();
-          });
-        },
-      );
-    }
-
     // вычисления для верхнего хинта у категории/статуса
     final _categoryEmpty = (_category ?? _categoryController.text.trim()).isEmpty;
     final _statusEmpty = (_status ?? _statusController.text.trim()).isEmpty;
@@ -1838,7 +2058,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                     spacing: 8,
                     runSpacing: 8,
                     children: [
-                      for (final label in const ['Новый', 'Напомнить', 'VIP'])
+                      for (final label in const ['Новый', 'VIP'])
                         ChoiceChip(
                           label: Text(label),
                           selected: _tags.contains(label),
@@ -1949,68 +2169,135 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
                   },
                   headerActions: [
                     IconButton(
-                      tooltip: 'Добавить напоминание',
                       onPressed: _contact.id == null ? null : _addReminder,
+                      tooltip: 'Добавить напоминание',
                       icon: const Icon(Icons.add_alert_outlined),
                     ),
                   ],
-                  children: _reminders.isEmpty
-                      ? [
-                          Card(
-                            elevation: 0,
-                            child: Padding(
-                              padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
-                              child: Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  const Icon(
-                                    Icons.notifications_active_outlined,
-                                    size: 48,
-                                  ),
-                                  const SizedBox(height: 12),
-                                  Text(
-                                    _contact.id == null
-                                        ? 'Сохраните контакт, чтобы добавлять напоминания'
-                                        : 'Нет напоминаний',
-                                    style: Theme.of(context).textTheme.titleMedium,
-                                    textAlign: TextAlign.center,
-                                  ),
-                                  const SizedBox(height: 24),
-                                  FilledButton.icon(
-                                    onPressed:
-                                        _contact.id == null ? null : _addReminder,
-                                    icon: const Icon(Icons.add),
-                                    label: const Text('Добавить напоминание'),
-                                  ),
-                                ],
+                  children: [
+                    if (_contact.id == null)
+                      Card(
+                        elevation: 0,
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(
+                                Icons.notifications_active_outlined,
+                                size: 48,
                               ),
-                            ),
+                              const SizedBox(height: 12),
+                              Text(
+                                'Сохраните контакт, чтобы добавлять напоминания',
+                                style: Theme.of(context).textTheme.titleMedium,
+                                textAlign: TextAlign.center,
+                              ),
+                            ],
                           ),
-                        ]
-                      : [
-                          Card(
-                            elevation: 0,
-                            child: Column(
-                              children: [
-                                for (var i = 0; i < _reminders.length; i++)
-                                  _reminderRow(
-                                    _reminders[i],
-                                    isLast: i == _reminders.length - 1,
+                        ),
+                      )
+                    else ...[
+                      Center(
+                        child: ToggleButtons(
+                          isSelected: [
+                            _selectedRemindersTab == 0,
+                            _selectedRemindersTab == 1,
+                          ],
+                          borderRadius: BorderRadius.circular(20),
+                          constraints: const BoxConstraints(minHeight: 36, minWidth: 120),
+                          onPressed: (index) {
+                            setState(() => _selectedRemindersTab = index);
+                          },
+                          children: const [
+                            Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 12),
+                              child: Text('Активные'),
+                            ),
+                            Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 12),
+                              child: Text('Завершённые'),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Builder(
+                        builder: (context) {
+                          final isCompletedTab = _selectedRemindersTab == 1;
+                          final reminders =
+                              isCompletedTab ? _completedReminders : _activeReminders;
+                          final emptyText = isCompletedTab
+                              ? 'Нет завершённых напоминаний'
+                              : 'Нет активных напоминаний';
+
+                          if (reminders.isEmpty)
+                            return Card(
+                              elevation: 0,
+                              child: Padding(
+                                padding:
+                                    const EdgeInsets.fromLTRB(24, 32, 24, 24),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Icon(
+                                      Icons.notifications_active_outlined,
+                                      size: 48,
+                                    ),
+                                    const SizedBox(height: 12),
+                                    Text(
+                                      emptyText,
+                                      style:
+                                          Theme.of(context).textTheme.titleMedium,
+                                      textAlign: TextAlign.center,
+                                    ),
+                                    if (!isCompletedTab) ...[
+                                      const SizedBox(height: 20),
+                                      FilledButton.icon(
+                                        onPressed: _addReminder,
+                                        icon: const Icon(Icons.add_alert_outlined),
+                                        label: const Text('Добавить напоминание'),
+                                      ),
+                                    ],
+                                  ],
+                                ),
+                              ),
+                            );
+
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              if (isCompletedTab)
+                                Align(
+                                  alignment: Alignment.centerRight,
+                                  child: TextButton.icon(
+                                    onPressed: _clearCompletedReminders,
+                                    icon: const Icon(Icons.delete_sweep_outlined),
+                                    label: const Text('Очистить всё'),
                                   ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(height: 12),
-                          Align(
-                            alignment: Alignment.centerLeft,
-                            child: FilledButton.icon(
-                              onPressed:
-                                  _contact.id == null ? null : _addReminder,
-                              icon: const Icon(Icons.add),
-                              label: const Text('Добавить напоминание'),
-                            ),
-                          ),
-                        ],
+                                ),
+                              if (isCompletedTab) const SizedBox(height: 8),
+                              Card(
+                                elevation: 0,
+                                child: Column(
+                                  children: [
+                                    for (var i = 0; i < reminders.length; i++) ...[
+                                      _reminderTile(
+                                        reminders[i],
+                                        completed: isCompletedTab,
+                                      ),
+                                      if (i != reminders.length - 1)
+                                        const Divider(height: 0),
+                                    ],
+                                  ],
+                                ),
+                              ),
+                            ],
+                          );
+                        },
+                      ),
+                    ],
+                  ],
                 ),
               ),
 
@@ -2178,7 +2465,11 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> {
     _status = c.status;
     _statusController.text = c.status;
 
-    _tags..clear()..addAll(c.tags);
+    _tags
+      ..clear()
+      ..addAll(c.tags.where((tag) =>
+          tag != Contact.reminderTagName &&
+          tag != Contact.legacyReminderTagName));
 
     _commentController.text = c.comment ?? '';
     _addedDate = c.createdAt;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -10,8 +10,8 @@ import 'package:intl/intl.dart';
 import 'add_contact_screen.dart';
 import 'settings_screen.dart';
 import 'contact_list_screen.dart';
+import 'all_reminders_screen.dart';
 import '../services/contact_database.dart';
-import '../services/push_notifications.dart';
 
 
 /// ---------------------
@@ -43,8 +43,7 @@ abstract class R {
       'Создайте первый контакт. Ниже можно открыть списки по категориям.';
   static const chipHintOpenList = 'Откройте список по категории';
   static const dataUpdated = 'Данные обновлены';
-  static const showNotification = 'Показать уведомление';
-  static const notificationMessage = 'Это тестовое push-уведомление.';
+  static const remindersOverview = 'Все напоминания';
 
   static String summaryUnknown(int count) {
     if (count <= 0) return summaryAllKnown;
@@ -138,10 +137,15 @@ extension ContactCategoryX on ContactCategory {
 /// Типобезопасные счётчики
 /// ---------------------
 class Counts {
-  final Map<ContactCategory, int> _m;
-  const Counts(this._m);
+  final Map<ContactCategory, int> _contacts;
+  final Map<ContactCategory, int> _reminders;
+  const Counts(
+    this._contacts, [
+    Map<ContactCategory, int>? reminders,
+  ]) : _reminders = reminders ?? const {};
 
-  int of(ContactCategory c) => _m[c] ?? 0;
+  int of(ContactCategory c) => _contacts[c] ?? 0;
+  int remindersOf(ContactCategory c) => _reminders[c] ?? 0;
 
   bool get allZero => ContactCategory.values.every((c) => of(c) == 0);
 
@@ -160,12 +164,16 @@ class Counts {
     if (other is! Counts) return false;
     for (final c in ContactCategory.values) {
       if (of(c) != other.of(c)) return false;
+      if (remindersOf(c) != other.remindersOf(c)) return false;
     }
     return true;
   }
 
   @override
-  int get hashCode => Object.hashAll(ContactCategory.values.map(of));
+  int get hashCode => Object.hashAll([
+        for (final c in ContactCategory.values) of(c),
+        for (final c in ContactCategory.values) remindersOf(c),
+      ]);
 }
 
 /// ---------------------
@@ -230,17 +238,30 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
   }
 
   Future<Counts> _loadCounts() async {
-    final partner = await _safe(
-        ContactDatabase.instance.countByCategory(ContactCategory.partner.dbKey));
-    final client = await _safe(
-        ContactDatabase.instance.countByCategory(ContactCategory.client.dbKey));
-    final prospect = await _safe(
-        ContactDatabase.instance.countByCategory(ContactCategory.prospect.dbKey));
-    return Counts({
-      ContactCategory.partner: partner,
-      ContactCategory.client: client,
-      ContactCategory.prospect: prospect,
-    });
+    final db = ContactDatabase.instance;
+    final contactCounts = await Future.wait<int>([
+      _safe(db.countByCategory(ContactCategory.partner.dbKey)),
+      _safe(db.countByCategory(ContactCategory.client.dbKey)),
+      _safe(db.countByCategory(ContactCategory.prospect.dbKey)),
+    ]);
+    final reminderCounts = await Future.wait<int>([
+      _safe(db.activeReminderCountByCategory(ContactCategory.partner.dbKey)),
+      _safe(db.activeReminderCountByCategory(ContactCategory.client.dbKey)),
+      _safe(db.activeReminderCountByCategory(ContactCategory.prospect.dbKey)),
+    ]);
+
+    return Counts(
+      {
+        ContactCategory.partner: contactCounts[0],
+        ContactCategory.client: contactCounts[1],
+        ContactCategory.prospect: contactCounts[2],
+      },
+      {
+        ContactCategory.partner: reminderCounts[0],
+        ContactCategory.client: reminderCounts[1],
+        ContactCategory.prospect: reminderCounts[2],
+      },
+    );
   }
 
   void _scheduleRefresh() {
@@ -352,43 +373,6 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
     }
   }
 
-  Future<void> _pickAndScheduleReminder() async {
-    // 1) Выбор даты/времени
-    final now = DateTime.now();
-    final date = await showDatePicker(
-      context: context,
-      initialDate: now.add(const Duration(days: 0)),
-      firstDate: now,
-      lastDate: now.add(const Duration(days: 365)),
-      helpText: 'Выберите дату',
-    );
-    if (date == null) return;
-
-    final time = await showTimePicker(
-      context: context,
-      initialTime: TimeOfDay.fromDateTime(now.add(const Duration(minutes: 5))),
-      helpText: 'Выберите время',
-    );
-    if (time == null) return;
-
-    final when = DateTime(date.year, date.month, date.day, time.hour, time.minute);
-
-    // 2) Планируем одноразовое
-    await PushNotifications.scheduleOneTime(
-      id: 2001,
-      whenLocal: when,
-      title: R.appTitle,
-      body: 'Напоминание на ${DateFormat('d MMMM, HH:mm', 'ru').format(when)}',
-      exact: true, // если не критично — можно false, чтобы не спрашивать exact alarm
-    );
-
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Напоминание запланировано на '
-          '${DateFormat('d MMMM, HH:mm', 'ru').format(when)}')),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -398,14 +382,9 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
         // В AppBar actions:
         actions: [
           IconButton(
-            tooltip: R.showNotification,
+            tooltip: R.remindersOverview,
             icon: const Icon(Icons.notifications_active_outlined),
-            onPressed: _showDemoNotification,
-          ),
-          IconButton(
-            tooltip: 'Запланировать напоминание',
-            icon: const Icon(Icons.schedule),
-            onPressed: _pickAndScheduleReminder,
+            onPressed: _openAllReminders,
           ),
         ],
       ),
@@ -458,7 +437,10 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
               // если есть хоть какие-то прошлые данные — используем их
               final counts = snapshot.data ??
                   _lastGoodCounts ??
-                  Counts({ for (final c in ContactCategory.values) c: 0 });
+                  Counts(
+                    { for (final c in ContactCategory.values) c: 0 },
+                    { for (final c in ContactCategory.values) c: 0 },
+                  );
 
               // если пришла ошибка и данных нет вообще — показываем карточку ошибки
               if (snapshot.hasError && !hasSomeData) {
@@ -509,12 +491,14 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
 
                   final items = ContactCategory.values.map((cat) {
                     final c = counts.of(cat);
+                    final reminders = counts.remindersOf(cat);
                     final subtitle = (c < 0) ? R.unknown : cat.russianCount(c);
                     final chip = (c < 0) ? '—' : _nfRu.format(c);
                     return _CategoryCard(
                       category: cat,
                       subtitle: subtitle,
                       trailingCount: chip,
+                      reminderCount: reminders,
                       isLoading: false, // НЕ скрываем карточки при refresh
                       onTap: () {
                         if (!kIsWeb) HapticFeedback.selectionClick();
@@ -637,13 +621,11 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
     );
   }
 
-  Future<void> _showDemoNotification() async {
-    await PushNotifications.showNotification(
-      id: 1001,
-      title: R.appTitle,
-      body: R.notificationMessage,
+  void _openAllReminders() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const AllRemindersScreen()),
     );
-    if (!mounted) return;
   }
 }
 
@@ -824,6 +806,7 @@ class _CategoryCard extends StatefulWidget {
   final String? trailingCount; // null — без чипа (скелетон/загрузка)
   final VoidCallback onTap;
   final bool isLoading;
+  final int reminderCount;
 
   const _CategoryCard({
     super.key,
@@ -831,6 +814,7 @@ class _CategoryCard extends StatefulWidget {
     required this.subtitle,
     required this.onTap,
     required this.trailingCount,
+    required this.reminderCount,
     this.isLoading = false,
   });
 
@@ -839,7 +823,8 @@ class _CategoryCard extends StatefulWidget {
         subtitle = R.loading,
         trailingCount = null,
         onTap = _noop,
-        isLoading = true;
+        isLoading = true,
+        reminderCount = 0;
 
   static void _noop() {}
   @override
@@ -854,14 +839,57 @@ class _CategoryCardState extends State<_CategoryCard> {
     setState(() => _pressed = value);
   }
 
+  Widget _iconWithBadge(ThemeData theme, ColorScheme scheme) {
+    final count = widget.reminderCount;
+    final baseIcon = Icon(widget.category.icon, size: 32, color: scheme.primary);
+    if (count <= 0) return baseIcon;
+
+    final badgeText = count > 99 ? '99+' : '$count';
+    final badgeColor = scheme.error;
+    final onBadge = scheme.onError;
+    final badgeTextStyle = theme.textTheme.labelSmall?.copyWith(
+          color: onBadge,
+          fontWeight: FontWeight.w600,
+        ) ??
+        TextStyle(
+          color: onBadge,
+          fontWeight: FontWeight.w600,
+          fontSize: 10,
+        );
+
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        baseIcon,
+        Positioned(
+          right: -10,
+          top: -6,
+          child: Tooltip(
+            message: 'Активные напоминания: $count',
+            child: Semantics(
+              label: 'Активных напоминаний: $count',
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: badgeColor,
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(badgeText, style: badgeTextStyle),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final isLoading = widget.isLoading;
 
-    Widget leadingIcon =
-    Icon(widget.category.icon, size: 32, color: colorScheme.primary);
+    Widget leadingIcon = _iconWithBadge(theme, colorScheme);
 
     if (!isLoading) {
       leadingIcon = Hero(

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
 import '../models/reminder.dart';
+import '../models/reminder_with_contact_info.dart';
 
 class ContactDatabase {
   ContactDatabase._();
@@ -23,8 +24,8 @@ class ContactDatabase {
 
     _db = await openDatabase(
       path,
-      // ВАЖНО: поднимаем версию до 3, чтобы сработала миграция с FK + CASCADE и напоминаниями
-      version: 3,
+      // ВАЖНО: поднимаем версию до 4, чтобы сработала миграция с FK + CASCADE и напоминаниями
+      version: 4,
 
       // Включаем поддержку внешних ключей (иначе SQLite их игнорирует)
       onConfigure: (db) async {
@@ -73,6 +74,7 @@ class ContactDatabase {
             text TEXT NOT NULL,
             remindAt INTEGER NOT NULL,
             createdAt INTEGER NOT NULL,
+            completedAt INTEGER,
             FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
           )
         ''');
@@ -123,10 +125,24 @@ class ContactDatabase {
               text TEXT NOT NULL,
               remindAt INTEGER NOT NULL,
               createdAt INTEGER NOT NULL,
+              completedAt INTEGER,
               FOREIGN KEY(contactId) REFERENCES contacts(id) ON DELETE CASCADE
             )
           ''');
           await db.execute('CREATE INDEX IF NOT EXISTS idx_reminders_contactId_remindAt ON reminders(contactId, remindAt)');
+        }
+
+        if (oldV < 4) {
+          final columns = await db.rawQuery('PRAGMA table_info(reminders)');
+          final hasCompletedAt = columns.any((column) {
+            final name = column['name'];
+            if (name is String) return name == 'completedAt';
+            return false;
+          });
+          if (!hasCompletedAt) {
+            await db
+                .execute('ALTER TABLE reminders ADD COLUMN completedAt INTEGER');
+          }
         }
       },
     );
@@ -164,11 +180,21 @@ class ContactDatabase {
 
   Future<List<Contact>> contactsByCategory(String category) async {
     final db = await database;
-    final maps = await db.query(
-      'contacts',
-      where: 'category = ?',
-      whereArgs: [category],
-      orderBy: 'createdAt DESC',
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final maps = await db.rawQuery(
+      '''
+      SELECT c.*,
+             COALESCE(SUM(CASE
+               WHEN r.completedAt IS NULL AND r.remindAt >= ? THEN 1
+               ELSE 0
+             END), 0) AS activeReminderCount
+        FROM contacts c
+        LEFT JOIN reminders r ON r.contactId = c.id
+       WHERE c.category = ?
+       GROUP BY c.id
+       ORDER BY c.createdAt DESC
+      '''.trim(),
+      [now, category],
     );
     return maps.map(Contact.fromMap).toList();
   }
@@ -179,13 +205,22 @@ class ContactDatabase {
     int offset = 0,
   }) async {
     final db = await database;
-    final maps = await db.query(
-      'contacts',
-      where: 'category = ?',
-      whereArgs: [category],
-      orderBy: 'createdAt DESC',
-      limit: limit,
-      offset: offset,
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final maps = await db.rawQuery(
+      '''
+      SELECT c.*,
+             COALESCE(SUM(CASE
+               WHEN r.completedAt IS NULL AND r.remindAt >= ? THEN 1
+               ELSE 0
+             END), 0) AS activeReminderCount
+        FROM contacts c
+        LEFT JOIN reminders r ON r.contactId = c.id
+       WHERE c.category = ?
+       GROUP BY c.id
+       ORDER BY c.createdAt DESC
+       LIMIT ? OFFSET ?
+      '''.trim(),
+      [now, category, limit, offset],
     );
     return maps.map(Contact.fromMap).toList();
   }
@@ -214,6 +249,23 @@ class ContactDatabase {
     final result = await db.rawQuery(
       'SELECT COUNT(*) as c FROM contacts WHERE category = ?',
       [category],
+    );
+    return Sqflite.firstIntValue(result) ?? 0;
+  }
+
+  Future<int> activeReminderCountByCategory(String category) async {
+    final db = await database;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final result = await db.rawQuery(
+      '''
+      SELECT COUNT(r.id) as c
+        FROM reminders r
+        JOIN contacts c ON c.id = r.contactId
+       WHERE c.category = ?
+         AND r.completedAt IS NULL
+         AND r.remindAt >= ?
+      '''.trim(),
+      [category, now],
     );
     return Sqflite.firstIntValue(result) ?? 0;
   }
@@ -314,15 +366,123 @@ class ContactDatabase {
     return rows;
   }
 
-  Future<List<Reminder>> remindersByContact(int contactId) async {
+  Future<int> deleteCompletedRemindersForContact(int contactId) async {
     final db = await database;
+    final rows = await db.delete(
+      'reminders',
+      where: 'contactId = ? AND completedAt IS NOT NULL',
+      whereArgs: [contactId],
+    );
+    if (rows > 0) {
+      _bumpRevision();
+    }
+    return rows;
+  }
+
+  Future<List<Reminder>> completeDueRemindersForContact(int contactId) async {
+    final db = await database;
+    final nowEpoch = DateTime.now().millisecondsSinceEpoch;
+    final dueMaps = await db.query(
+      'reminders',
+      where: 'contactId = ? AND completedAt IS NULL AND remindAt <= ?',
+      whereArgs: [contactId, nowEpoch],
+    );
+
+    if (dueMaps.isEmpty) return const [];
+
+    final dueReminders = dueMaps.map(Reminder.fromMap).toList();
+    final updatedReminders = <Reminder>[];
+    final batch = db.batch();
+    final completionMoment = DateTime.now();
+
+    for (final reminder in dueReminders) {
+      final updated = reminder.copyWith(completedAt: completionMoment);
+      updatedReminders.add(updated);
+      batch.update(
+        'reminders',
+        updated.toMap(),
+        where: 'id = ?',
+        whereArgs: [reminder.id],
+      );
+    }
+
+    await batch.commit(noResult: true);
+    _bumpRevision();
+    return updatedReminders;
+  }
+
+  Future<List<Reminder>> remindersByContact(
+    int contactId, {
+    bool onlyActive = false,
+    bool onlyCompleted = false,
+  }) async {
+    assert(!(onlyActive && onlyCompleted),
+        'Нельзя одновременно запрашивать только активные и только завершённые напоминания');
+    final db = await database;
+    final where = StringBuffer('contactId = ?');
+    final whereArgs = <Object?>[contactId];
+    var orderBy = 'remindAt ASC';
+
+    if (onlyActive) {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      where
+        ..write(' AND completedAt IS NULL')
+        ..write(' AND remindAt >= ?');
+      whereArgs.add(now);
+      orderBy = 'remindAt ASC';
+    } else if (onlyCompleted) {
+      where.write(' AND completedAt IS NOT NULL');
+      orderBy = 'completedAt DESC';
+    }
+
     final maps = await db.query(
       'reminders',
-      where: 'contactId = ?',
-      whereArgs: [contactId],
-      orderBy: 'remindAt ASC',
+      where: where.toString(),
+      whereArgs: whereArgs,
+      orderBy: orderBy,
     );
     return maps.map(Reminder.fromMap).toList();
+  }
+
+  Future<List<ReminderWithContactInfo>> remindersWithContactInfo() async {
+    final db = await database;
+    final rows = await db.rawQuery('''
+      SELECT r.id AS reminder_id,
+             r.contactId AS reminder_contactId,
+             r.text AS reminder_text,
+             r.remindAt AS reminder_remindAt,
+             r.createdAt AS reminder_createdAt,
+             r.completedAt AS reminder_completedAt,
+             c.name AS contact_name,
+             c.category AS contact_category
+        FROM reminders r
+        JOIN contacts c ON c.id = r.contactId
+       ORDER BY r.remindAt ASC, r.id ASC
+    ''');
+
+    return rows.map((row) {
+      final reminder = Reminder(
+        id: row['reminder_id'] as int?,
+        contactId: row['reminder_contactId'] as int,
+        text: row['reminder_text'] as String,
+        remindAt:
+            DateTime.fromMillisecondsSinceEpoch(row['reminder_remindAt'] as int),
+        createdAt: DateTime.fromMillisecondsSinceEpoch(
+          row['reminder_createdAt'] as int,
+        ),
+        completedAt: row['reminder_completedAt'] != null
+            ? DateTime.fromMillisecondsSinceEpoch(
+                row['reminder_completedAt'] as int,
+              )
+            : null,
+      );
+
+      return ReminderWithContactInfo(
+        reminder: reminder,
+        contactName: row['contact_name'] as String,
+        contactCategory: row['contact_category'] as String,
+      );
+    }).toList();
   }
 
   // ================= Helpers для Undo =================


### PR DESCRIPTION
## Summary
- replace the home screen notification action with navigation to a new reminders overview and remove the old scheduling shortcut
- add a database helper and lightweight model for fetching reminders with their contact metadata
- implement an all reminders screen that groups entries by date, indicates status, and supports pull-to-refresh

## Testing
- not run (Flutter SDK unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68da44baef5883289ed3c05841d099e6