### PR TITLE
Disable reminder save button for non-future reminder times

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1038,7 +1038,6 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
       );
 
     var selected = initial?.remindAt ?? DateTime.now().add(const Duration(minutes: 1));
-    final now = DateTime.now();
 
     final result = await showModalBottomSheet<({String text, DateTime when})>(
       context: context,
@@ -1047,7 +1046,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
         return StatefulBuilder(
           builder: (context, setState) {
             final viewInsets = MediaQuery.of(context).viewInsets;
-            final minimumDate = selected.isBefore(now) ? selected : now;
+            final currentNow = DateTime.now();
+            final minimumDate = selected.isBefore(currentNow) ? selected : currentNow;
+            final canSave = selected.isAfter(currentNow);
 
             return AnimatedPadding(
               duration: const Duration(milliseconds: 150),
@@ -1079,14 +1080,16 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
                             ),
                             const SizedBox(width: 8),
                             FilledButton(
-                              onPressed: () {
-                                final text = controller.text.trim();
-                                if (text.isEmpty) {
-                                  showErrorBanner('Введите текст напоминания');
-                                  return;
-                                }
-                                Navigator.pop(sheetContext, (text: text, when: selected));
-                              },
+                              onPressed: canSave
+                                  ? () {
+                                      final text = controller.text.trim();
+                                      if (text.isEmpty) {
+                                        showErrorBanner('Введите текст напоминания');
+                                        return;
+                                      }
+                                      Navigator.pop(sheetContext, (text: text, when: selected));
+                                    }
+                                  : null,
                               child: const Text('Сохранить'),
                             ),
                           ],
@@ -1114,7 +1117,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
                           use24hFormat: true,
                           initialDateTime: selected,
                           minimumDate: minimumDate,
-                          maximumDate: now.add(const Duration(days: 365 * 5)),
+                          maximumDate: currentNow.add(const Duration(days: 365 * 5)),
                           onDateTimeChanged: (value) => setState(() => selected = value),
                         ),
                       ),


### PR DESCRIPTION
## Summary
- disable the save action in the reminder editor when the selected time is not in the future
- ensure the date picker limits are recalculated against the current time on rebuild

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68daa6ff5b44832897cbe6c2fb751493