### PR TITLE
Enforce minute-level validation for reminder saves

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1038,7 +1038,6 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
       );
 
     var selected = initial?.remindAt ?? DateTime.now().add(const Duration(minutes: 1));
-    final now = DateTime.now();
 
     final result = await showModalBottomSheet<({String text, DateTime when})>(
       context: context,
@@ -1047,7 +1046,19 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
         return StatefulBuilder(
           builder: (context, setState) {
             final viewInsets = MediaQuery.of(context).viewInsets;
-            final minimumDate = selected.isBefore(now) ? selected : now;
+            DateTime _minutePrecision(DateTime value) => DateTime(
+                  value.year,
+                  value.month,
+                  value.day,
+                  value.hour,
+                  value.minute,
+                );
+
+            final currentNow = DateTime.now();
+            final minuteNow = _minutePrecision(currentNow);
+            final minuteSelected = _minutePrecision(selected);
+            final minimumDate = minuteSelected.isBefore(minuteNow) ? selected : minuteNow;
+            final canSave = minuteSelected.isAfter(minuteNow);
 
             return AnimatedPadding(
               duration: const Duration(milliseconds: 150),
@@ -1079,14 +1090,16 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
                             ),
                             const SizedBox(width: 8),
                             FilledButton(
-                              onPressed: () {
-                                final text = controller.text.trim();
-                                if (text.isEmpty) {
-                                  showErrorBanner('Введите текст напоминания');
-                                  return;
-                                }
-                                Navigator.pop(sheetContext, (text: text, when: selected));
-                              },
+                              onPressed: canSave
+                                  ? () {
+                                      final text = controller.text.trim();
+                                      if (text.isEmpty) {
+                                        showErrorBanner('Введите текст напоминания');
+                                        return;
+                                      }
+                                      Navigator.pop(sheetContext, (text: text, when: selected));
+                                    }
+                                  : null,
                               child: const Text('Сохранить'),
                             ),
                           ],
@@ -1114,7 +1127,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
                           use24hFormat: true,
                           initialDateTime: selected,
                           minimumDate: minimumDate,
-                          maximumDate: now.add(const Duration(days: 365 * 5)),
+                          maximumDate: currentNow.add(const Duration(days: 365 * 5)),
                           onDateTimeChanged: (value) => setState(() => selected = value),
                         ),
                       ),


### PR DESCRIPTION
## Summary
- ensure the reminder editor disables saving when the selected time is in the current minute or any earlier moment by comparing timestamps at minute precision

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68daa6ff5b44832897cbe6c2fb751493