### PR TITLE
Refine all reminders card spacing and styling

### DIFF
--- a/lib/screens/all_reminders_screen.dart
+++ b/lib/screens/all_reminders_screen.dart
@@ -210,6 +210,8 @@ class _AllRemindersScreenState extends State<AllRemindersScreen> {
     final dateFormatter = DateFormat.yMMMMd('ru');
     final timeFormatter = DateFormat('HH:mm', 'ru');
     final completedFormatter = DateFormat('d MMMM, HH:mm', 'ru');
+    final reminderHighlightColor = theme.colorScheme.secondaryContainer;
+    final reminderHighlightTextColor = theme.colorScheme.onSecondaryContainer;
 
     return RefreshIndicator(
       onRefresh: _onRefresh,
@@ -231,12 +233,35 @@ class _AllRemindersScreenState extends State<AllRemindersScreen> {
                 child: Card(
                   child: ListTile(
                     leading: _ReminderStatusIcon(reminder: item.reminder),
-                    title: Text(item.reminder.text),
-                    subtitle: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(item.contactName),
-                        const SizedBox(height: 4),
+                    title: Text(
+                      item.contactName,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontSize:
+                            (theme.textTheme.titleMedium?.fontSize ?? 16) + 2,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    subtitle: Padding(
+                      padding: const EdgeInsets.only(top: 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            width: double.infinity,
+                            padding: const EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: reminderHighlightColor,
+                            borderRadius: const BorderRadius.all(Radius.circular(8)),
+                          ),
+                          child: Text(
+                            item.reminder.text,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: reminderHighlightTextColor,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 8),
                         Text(
                           '${timeFormatter.format(item.reminder.remindAt)} • ${item.contactCategory}',
                         ),


### PR DESCRIPTION
## Summary
- increase the name title size and add spacing before the reminder text container
- switch the reminder text highlight to the secondary container colors for a refreshed look

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dab64975108328b63432c3232b9cd5