### PR TITLE
Adjust all reminders styling

### DIFF
--- a/lib/screens/all_reminders_screen.dart
+++ b/lib/screens/all_reminders_screen.dart
@@ -154,8 +154,15 @@ class _AllRemindersScreenState extends State<AllRemindersScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: colorScheme.surface,
+        elevation: 0,
+        shadowColor: Colors.transparent,
+        surfaceTintColor: Colors.transparent,
+        scrolledUnderElevation: 0,
         title: const Text('Все напоминания'),
       ),
       body: _buildBody(context),
@@ -210,8 +217,12 @@ class _AllRemindersScreenState extends State<AllRemindersScreen> {
     final dateFormatter = DateFormat.yMMMMd('ru');
     final timeFormatter = DateFormat('HH:mm', 'ru');
     final completedFormatter = DateFormat('d MMMM, HH:mm', 'ru');
-    final reminderHighlightColor = theme.colorScheme.secondaryContainer;
-    final reminderHighlightTextColor = theme.colorScheme.onSecondaryContainer;
+    final colorScheme = theme.colorScheme;
+    final isDarkTheme = theme.brightness == Brightness.dark;
+    final reminderHighlightColor =
+        isDarkTheme ? colorScheme.surfaceContainerHighest : colorScheme.primary;
+    final reminderHighlightTextColor =
+        isDarkTheme ? colorScheme.onSurface : colorScheme.onPrimary;
 
     return RefreshIndicator(
       onRefresh: _onRefresh,


### PR DESCRIPTION
## Summary
- set the All Reminders app bar to use a static surface-colored background without scroll tinting
- restyle the reminder text field with a darker appearance for light themes while preserving dark-theme contrast

## Testing
- Not run (Flutter SDK not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dabc35ac7c83288e72ca63af407a64