### PR TITLE
Add settings navigation cards and placeholder detail screens

### DIFF
--- a/lib/screens/notifications_settings_screen.dart
+++ b/lib/screens/notifications_settings_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class NotificationsSettingsScreen extends StatelessWidget {
+  const NotificationsSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Уведомления')),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Text(
+            'Настройки уведомлений будут доступны позже.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/privacy_policy_screen.dart
+++ b/lib/screens/privacy_policy_screen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class PrivacyPolicyScreen extends StatelessWidget {
+  const PrivacyPolicyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Политика конфиденциальности')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          _SectionPlaceholder(title: '1. Общие положения'),
+          _SectionPlaceholder(title: '2. Сбор и использование данных'),
+          _SectionPlaceholder(title: '3. Хранение данных'),
+          _SectionPlaceholder(title: '4. Контактная информация'),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionPlaceholder extends StatelessWidget {
+  const _SectionPlaceholder({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        title: Text(title),
+        subtitle: const Text('Содержимое раздела будет добавлено позже.'),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
 
+import 'notifications_settings_screen.dart';
+import 'privacy_policy_screen.dart';
+import 'theme_settings_screen.dart';
+import 'user_agreement_screen.dart';
+
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
@@ -7,10 +12,60 @@ class SettingsScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Настройки')),
-      body: const Center(
-        child: Text('Страница в разработке'),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          _SettingsCard(
+            title: 'Уведомления',
+            description: 'Управление настройками уведомлений приложения.',
+            destination: NotificationsSettingsScreen(),
+          ),
+          _SettingsCard(
+            title: 'Тема',
+            description: 'Выбор светлой или тёмной темы интерфейса.',
+            destination: ThemeSettingsScreen(),
+          ),
+          _SettingsCard(
+            title: 'Политика конфиденциальности',
+            description: 'Ознакомьтесь с политикой обработки данных.',
+            destination: PrivacyPolicyScreen(),
+          ),
+          _SettingsCard(
+            title: 'Пользовательское соглашение',
+            description: 'Основные разделы пользовательского соглашения.',
+            destination: UserAgreementScreen(),
+          ),
+        ],
       ),
     );
   }
 }
 
+class _SettingsCard extends StatelessWidget {
+  const _SettingsCard({
+    required this.title,
+    required this.description,
+    required this.destination,
+  });
+
+  final String title;
+  final String description;
+  final Widget destination;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        title: Text(title),
+        subtitle: Text(description),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => destination),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/theme_settings_screen.dart
+++ b/lib/screens/theme_settings_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class ThemeSettingsScreen extends StatelessWidget {
+  const ThemeSettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Тема')),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16),
+          child: Text(
+            'Настройки темы появятся в будущих обновлениях.',
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/user_agreement_screen.dart
+++ b/lib/screens/user_agreement_screen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+class UserAgreementScreen extends StatelessWidget {
+  const UserAgreementScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Пользовательское соглашение')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          _SectionPlaceholder(title: '1. Предмет соглашения'),
+          _SectionPlaceholder(title: '2. Права и обязанности сторон'),
+          _SectionPlaceholder(title: '3. Ограничения и ответственность'),
+          _SectionPlaceholder(title: '4. Заключительные положения'),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionPlaceholder extends StatelessWidget {
+  const _SectionPlaceholder({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        title: Text(title),
+        subtitle: const Text('Содержимое раздела будет добавлено позже.'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- replace the settings placeholder with a list of navigation cards for notifications, theme, privacy policy, and user agreement
- add placeholder screens for notifications, theme, privacy policy, and user agreement content

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68dac19d13488328ba6c1404924c1a52