### PR TITLE
Implement theme and notification controls

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,11 +1,13 @@
-// lib/app.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'screens/home_screen.dart';
+import 'services/app_settings.dart';
 
 class App extends StatelessWidget {
-  const App({super.key});
+  const App({super.key, required this.settings});
+
+  final AppSettings settings;
 
   /// Глобальный ключ навигатора — доступен из любого места:
   /// App.navigatorKey.currentState?.push(...);
@@ -14,42 +16,50 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return OverlaySupport.global(
-      child: MaterialApp(
-        title: 'Touch NoteBook',
-        debugShowCheckedModeBanner: false, // 🔔 убирает "DEBUG" в углу
-        navigatorKey: navigatorKey, // <-- ВАЖНО: подключили ключ
-        navigatorObservers: [routeObserver],
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: Colors.deepPurple,
-            brightness: Brightness.light,
-          ),
-          appBarTheme: const AppBarTheme(
-            scrolledUnderElevation: 0,
-            surfaceTintColor: Colors.transparent,
-          ),
-          useMaterial3: true,
-        ),
-        darkTheme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: Colors.deepPurple,
-            brightness: Brightness.dark,
-          ),
-          useMaterial3: true,
-        ),
-        themeMode: ThemeMode.system,
-        localizationsDelegates: const [
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: const [
-          Locale('ru'),
-          Locale('en'),
-        ],
-        locale: const Locale('ru'),
-        home: const HomeScreen(),
+    return AppSettingsScope(
+      settings: settings,
+      child: AnimatedBuilder(
+        animation: settings,
+        builder: (context, _) {
+          return OverlaySupport.global(
+            child: MaterialApp(
+              title: 'Touch NoteBook',
+              debugShowCheckedModeBanner: false, // 🔔 убирает "DEBUG" в углу
+              navigatorKey: navigatorKey, // <-- ВАЖНО: подключили ключ
+              navigatorObservers: [routeObserver],
+              theme: ThemeData(
+                colorScheme: ColorScheme.fromSeed(
+                  seedColor: Colors.deepPurple,
+                  brightness: Brightness.light,
+                ),
+                appBarTheme: const AppBarTheme(
+                  scrolledUnderElevation: 0,
+                  surfaceTintColor: Colors.transparent,
+                ),
+                useMaterial3: true,
+              ),
+              darkTheme: ThemeData(
+                colorScheme: ColorScheme.fromSeed(
+                  seedColor: Colors.deepPurple,
+                  brightness: Brightness.dark,
+                ),
+                useMaterial3: true,
+              ),
+              themeMode: settings.themeMode,
+              localizationsDelegates: const [
+                GlobalMaterialLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+              ],
+              supportedLocales: const [
+                Locale('ru'),
+                Locale('en'),
+              ],
+              locale: const Locale('ru'),
+              home: const HomeScreen(),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 
 import 'app.dart';
+import 'services/app_settings.dart';
 import 'services/push_notifications.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  final settings = await AppSettings.load();
   await PushNotifications.ensureInitialized();
-  runApp(const App());
+  runApp(App(settings: settings));
 }
 

--- a/lib/screens/notifications_settings_screen.dart
+++ b/lib/screens/notifications_settings_screen.dart
@@ -1,21 +1,192 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
-class NotificationsSettingsScreen extends StatelessWidget {
+import '../services/app_settings.dart';
+import '../services/contact_database.dart';
+
+class NotificationsSettingsScreen extends StatefulWidget {
   const NotificationsSettingsScreen({super.key});
 
   @override
+  State<NotificationsSettingsScreen> createState() => _NotificationsSettingsScreenState();
+}
+
+class _NotificationsSettingsScreenState extends State<NotificationsSettingsScreen> {
+  final _db = ContactDatabase.instance;
+  late final VoidCallback _revisionListener;
+
+  int? _activeCount;
+  bool _loading = true;
+  bool _updating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _revisionListener = _loadActiveReminders;
+    _db.revision.addListener(_revisionListener);
+    _loadActiveReminders();
+  }
+
+  @override
+  void dispose() {
+    _db.revision.removeListener(_revisionListener);
+    super.dispose();
+  }
+
+  Future<void> _loadActiveReminders() async {
+    try {
+      final count = await _db.activeReminderCount();
+      if (!mounted) return;
+      setState(() {
+        _activeCount = count;
+        _loading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _activeCount = null;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _toggleNotifications(bool value) async {
+    if (_updating) return;
+    setState(() {
+      _updating = true;
+    });
+
+    final settings = AppSettingsScope.of(context);
+    try {
+      await settings.setNotificationsEnabled(value);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _updating = false;
+        });
+        unawaited(_loadActiveReminders());
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final settings = AppSettingsScope.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Уведомления')),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(16),
-          child: Text(
-            'Настройки уведомлений будут доступны позже.',
-            textAlign: TextAlign.center,
-          ),
-        ),
+      body: AnimatedBuilder(
+        animation: settings,
+        builder: (context, _) {
+          final enabled = settings.notificationsEnabled;
+          final count = _activeCount ?? 0;
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Card(
+                child: SwitchListTile.adaptive(
+                  value: enabled,
+                  onChanged: _updating ? null : _toggleNotifications,
+                  title: const Text('Пуш-уведомления'),
+                  subtitle: Text(
+                    enabled
+                        ? 'Уведомления включены'
+                        : 'Уведомления выключены',
+                  ),
+                  secondary: Icon(
+                    enabled ? Icons.notifications_active : Icons.notifications_off_outlined,
+                    color: enabled ? colorScheme.primary : colorScheme.outline,
+                  ),
+                ),
+              ),
+              if (_loading)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 32),
+                  child: Center(child: CircularProgressIndicator()),
+                )
+              else ...[
+                const SizedBox(height: 16),
+                Card(
+                  color: !enabled && count > 0
+                      ? colorScheme.errorContainer
+                      : colorScheme.surface,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              !enabled && count > 0
+                                  ? Icons.notification_important
+                                  : enabled
+                                      ? Icons.notifications
+                                      : Icons.notifications_paused_outlined,
+                              color: !enabled && count > 0
+                                  ? colorScheme.onErrorContainer
+                                  : colorScheme.primary,
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Text(
+                                _buildHeadline(enabled, count),
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  color: !enabled && count > 0
+                                      ? colorScheme.onErrorContainer
+                                      : null,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          _buildDescription(enabled, count),
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: !enabled && count > 0
+                                ? colorScheme.onErrorContainer
+                                : null,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+              if (_updating)
+                const Padding(
+                  padding: EdgeInsets.only(top: 12),
+                  child: Center(child: LinearProgressIndicator()),
+                ),
+            ],
+          );
+        },
       ),
     );
+  }
+
+  String _buildHeadline(bool enabled, int count) {
+    if (enabled && count > 0) {
+      return 'Активных напоминаний: $count';
+    }
+    if (!enabled && count > 0) {
+      return 'Напоминания не будут срабатывать';
+    }
+    return 'Активных напоминаний нет';
+  }
+
+  String _buildDescription(bool enabled, int count) {
+    if (!enabled && count > 0) {
+      return 'У вас запланировано $count напоминаний. Они останутся в списке, но уведомления не придут, пока вы не включите опцию.';
+    }
+    if (enabled && count > 0) {
+      return 'Мы напомним вам о каждом событии вовремя. При необходимости вы можете управлять напоминаниями в карточках контактов.';
+    }
+    return 'Создавайте напоминания у контактов, чтобы приложение подсказывало о важных событиях.';
   }
 }

--- a/lib/screens/privacy_policy_screen.dart
+++ b/lib/screens/privacy_policy_screen.dart
@@ -7,31 +7,14 @@ class PrivacyPolicyScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Политика конфиденциальности')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: const [
-          _SectionPlaceholder(title: '1. Общие положения'),
-          _SectionPlaceholder(title: '2. Сбор и использование данных'),
-          _SectionPlaceholder(title: '3. Хранение данных'),
-          _SectionPlaceholder(title: '4. Контактная информация'),
-        ],
-      ),
-    );
-  }
-}
-
-class _SectionPlaceholder extends StatelessWidget {
-  const _SectionPlaceholder({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      child: ListTile(
-        title: Text(title),
-        subtitle: const Text('Содержимое раздела будет добавлено позже.'),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'Текст политики конфиденциальности появится здесь позже.',
+            textAlign: TextAlign.center,
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -17,22 +17,22 @@ class SettingsScreen extends StatelessWidget {
         children: const [
           _SettingsCard(
             title: 'Уведомления',
-            description: 'Управление настройками уведомлений приложения.',
+            icon: Icons.notifications_active_outlined,
             destination: NotificationsSettingsScreen(),
           ),
           _SettingsCard(
             title: 'Тема',
-            description: 'Выбор светлой или тёмной темы интерфейса.',
+            icon: Icons.brightness_6_outlined,
             destination: ThemeSettingsScreen(),
           ),
           _SettingsCard(
             title: 'Политика конфиденциальности',
-            description: 'Ознакомьтесь с политикой обработки данных.',
+            icon: Icons.privacy_tip_outlined,
             destination: PrivacyPolicyScreen(),
           ),
           _SettingsCard(
             title: 'Пользовательское соглашение',
-            description: 'Основные разделы пользовательского соглашения.',
+            icon: Icons.receipt_long_outlined,
             destination: UserAgreementScreen(),
           ),
         ],
@@ -44,12 +44,12 @@ class SettingsScreen extends StatelessWidget {
 class _SettingsCard extends StatelessWidget {
   const _SettingsCard({
     required this.title,
-    required this.description,
+    required this.icon,
     required this.destination,
   });
 
   final String title;
-  final String description;
+  final IconData icon;
   final Widget destination;
 
   @override
@@ -57,8 +57,8 @@ class _SettingsCard extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       child: ListTile(
+        leading: Icon(icon),
         title: Text(title),
-        subtitle: Text(description),
         trailing: const Icon(Icons.chevron_right),
         onTap: () {
           Navigator.of(context).push(

--- a/lib/screens/theme_settings_screen.dart
+++ b/lib/screens/theme_settings_screen.dart
@@ -1,18 +1,257 @@
 import 'package:flutter/material.dart';
 
-class ThemeSettingsScreen extends StatelessWidget {
+import '../services/app_settings.dart';
+
+class ThemeSettingsScreen extends StatefulWidget {
   const ThemeSettingsScreen({super.key});
 
   @override
+  State<ThemeSettingsScreen> createState() => _ThemeSettingsScreenState();
+}
+
+class _ThemeSettingsScreenState extends State<ThemeSettingsScreen> {
+  Alignment _focusAlignment = const Alignment(-0.9, -0.4);
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final settings = AppSettingsScope.of(context);
+    final alignment = _alignmentForMode(settings.themeMode);
+    if (_focusAlignment != alignment) {
+      _focusAlignment = alignment;
+    }
+  }
+
+  Alignment _alignmentForMode(ThemeMode mode) {
+    switch (mode) {
+      case ThemeMode.dark:
+        return const Alignment(0.9, -0.4);
+      case ThemeMode.light:
+        return const Alignment(-0.9, -0.4);
+      case ThemeMode.system:
+        final brightness = MediaQuery.maybeOf(context)?.platformBrightness;
+        if (brightness == Brightness.dark) {
+          return const Alignment(0.9, -0.4);
+        }
+        return const Alignment(-0.9, -0.4);
+    }
+  }
+
+  Future<void> _onSelect(ThemeMode mode) async {
+    final settings = AppSettingsScope.of(context);
+    await settings.setThemeMode(mode);
+    if (!mounted) return;
+    setState(() {
+      _focusAlignment = _alignmentForMode(mode);
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final settings = AppSettingsScope.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Тема')),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(16),
-          child: Text(
-            'Настройки темы появятся в будущих обновлениях.',
-            textAlign: TextAlign.center,
+      body: AnimatedBuilder(
+        animation: settings,
+        builder: (context, _) {
+          final mode = settings.themeMode;
+          final effectiveMode = mode == ThemeMode.system
+              ? (MediaQuery.of(context).platformBrightness == Brightness.dark
+                  ? ThemeMode.dark
+                  : ThemeMode.light)
+              : mode;
+
+          final highlightColor = effectiveMode == ThemeMode.dark
+              ? Colors.indigo.shade700.withOpacity(0.6)
+              : Colors.amber.shade200.withOpacity(0.7);
+
+          return Stack(
+            children: [
+              Positioned.fill(
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 600),
+                  curve: Curves.easeOutCubic,
+                  decoration: BoxDecoration(
+                    gradient: RadialGradient(
+                      center: _focusAlignment,
+                      radius: 1.2,
+                      colors: [
+                        highlightColor,
+                        colorScheme.surface,
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              Positioned.fill(
+                child: ListView(
+                  padding: const EdgeInsets.all(16),
+                  children: [
+                    Text(
+                      'Выберите оформление приложения',
+                      style: theme.textTheme.titleLarge,
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: _ThemeOptionCard(
+                            title: 'Дневная тема',
+                            description: 'Яркая палитра и светлый фон.',
+                            icon: Icons.wb_sunny_rounded,
+                            selected: effectiveMode == ThemeMode.light,
+                            onTap: () => _onSelect(ThemeMode.light),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: _ThemeOptionCard(
+                            title: 'Ночная тема',
+                            description: 'Глубокие тона и мягкий контраст.',
+                            icon: Icons.nights_stay_rounded,
+                            selected: effectiveMode == ThemeMode.dark,
+                            onTap: () => _onSelect(ThemeMode.dark),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Icon(
+                                  effectiveMode == ThemeMode.dark
+                                      ? Icons.dark_mode_outlined
+                                      : Icons.light_mode_outlined,
+                                  color: colorScheme.primary,
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: Text(
+                                    effectiveMode == ThemeMode.dark
+                                        ? 'Активна ночная тема'
+                                        : 'Активна дневная тема',
+                                    style: theme.textTheme.titleMedium,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              effectiveMode == ThemeMode.dark
+                                  ? 'Ночная тема снижает нагрузку на глаза и экономит заряд батареи в условиях слабого освещения.'
+                                  : 'Дневная тема подчёркивает детали интерфейса и обеспечивает максимальную читаемость в светлых условиях.',
+                              style: theme.textTheme.bodyMedium,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ThemeOptionCard extends StatelessWidget {
+  const _ThemeOptionCard({
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String title;
+  final String description;
+  final IconData icon;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final borderRadius = BorderRadius.circular(20);
+
+    return Card(
+      elevation: selected ? 4 : 0,
+      shape: RoundedRectangleBorder(borderRadius: borderRadius),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: borderRadius,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOutCubic,
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            borderRadius: borderRadius,
+            color: selected
+                ? colorScheme.primaryContainer.withOpacity(0.55)
+                : colorScheme.surface,
+            border: Border.all(
+              color: selected
+                  ? colorScheme.primary
+                  : colorScheme.outlineVariant,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                icon,
+                size: 48,
+                color: selected
+                    ? colorScheme.onPrimaryContainer
+                    : colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                description,
+                style: theme.textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    selected ? 'Выбрано' : 'Выбрать',
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: selected
+                          ? colorScheme.onPrimaryContainer
+                          : colorScheme.primary,
+                    ),
+                  ),
+                  Icon(
+                    selected ? Icons.check_circle : Icons.circle_outlined,
+                    color: selected
+                        ? colorScheme.onPrimaryContainer
+                        : colorScheme.primary,
+                  ),
+                ],
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/screens/user_agreement_screen.dart
+++ b/lib/screens/user_agreement_screen.dart
@@ -7,31 +7,14 @@ class UserAgreementScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Пользовательское соглашение')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: const [
-          _SectionPlaceholder(title: '1. Предмет соглашения'),
-          _SectionPlaceholder(title: '2. Права и обязанности сторон'),
-          _SectionPlaceholder(title: '3. Ограничения и ответственность'),
-          _SectionPlaceholder(title: '4. Заключительные положения'),
-        ],
-      ),
-    );
-  }
-}
-
-class _SectionPlaceholder extends StatelessWidget {
-  const _SectionPlaceholder({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.only(bottom: 12),
-      child: ListTile(
-        title: Text(title),
-        subtitle: const Text('Содержимое раздела будет добавлено позже.'),
+      body: const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'Раздел пользовательского соглашения находится в разработке.',
+            textAlign: TextAlign.center,
+          ),
+        ),
       ),
     );
   }

--- a/lib/services/app_settings.dart
+++ b/lib/services/app_settings.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/reminder_with_contact_info.dart';
+import 'contact_database.dart';
+import 'push_notifications.dart';
+
+class AppSettings extends ChangeNotifier {
+  AppSettings._(this._themeMode, this._notificationsEnabled);
+
+  static const _themeKey = 'app_theme_mode';
+  static const _notificationsKey = 'app_notifications_enabled';
+
+  ThemeMode _themeMode;
+  bool _notificationsEnabled;
+
+  ThemeMode get themeMode => _themeMode;
+  bool get notificationsEnabled => _notificationsEnabled;
+
+  static Future<AppSettings> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final storedTheme = prefs.getString(_themeKey);
+    final themeMode = switch (storedTheme) {
+      'light' => ThemeMode.light,
+      'dark' => ThemeMode.dark,
+      'system' => ThemeMode.system,
+      _ => ThemeMode.system,
+    };
+    final notificationsEnabled =
+        prefs.getBool(_notificationsKey) ?? true;
+
+    final settings = AppSettings._(themeMode, notificationsEnabled);
+    PushNotifications.setEnabled(notificationsEnabled);
+    return settings;
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    if (_themeMode == mode) return;
+    _themeMode = mode;
+    notifyListeners();
+
+    final prefs = await SharedPreferences.getInstance();
+    final value = switch (mode) {
+      ThemeMode.light => 'light',
+      ThemeMode.dark => 'dark',
+      ThemeMode.system => 'system',
+    };
+    await prefs.setString(_themeKey, value);
+  }
+
+  Future<void> setNotificationsEnabled(bool value) async {
+    if (_notificationsEnabled == value) return;
+    _notificationsEnabled = value;
+    notifyListeners();
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_notificationsKey, value);
+
+    PushNotifications.setEnabled(value);
+    if (!value) {
+      await PushNotifications.cancelAll();
+      return;
+    }
+
+    unawaited(_rescheduleActiveReminders());
+  }
+
+  Future<void> _rescheduleActiveReminders() async {
+    final reminders = await ContactDatabase.instance.remindersWithContactInfo();
+    final now = DateTime.now();
+    final active = reminders.where((entry) {
+      final reminder = entry.reminder;
+      final isCompleted = reminder.completedAt != null;
+      final isFuture = !reminder.remindAt.isBefore(now);
+      return !isCompleted && isFuture;
+    });
+
+    for (final ReminderWithContactInfo entry in active) {
+      final reminder = entry.reminder;
+      if (reminder.id == null) continue;
+      await PushNotifications.scheduleOneTime(
+        id: reminder.id!,
+        whenLocal: reminder.remindAt,
+        title: 'Напоминание: ${entry.contactName}',
+        body: reminder.text,
+      );
+    }
+  }
+}
+
+class AppSettingsScope extends InheritedNotifier<AppSettings> {
+  const AppSettingsScope({
+    super.key,
+    required AppSettings settings,
+    required super.child,
+  }) : super(notifier: settings);
+
+  static AppSettings of(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<AppSettingsScope>();
+    assert(scope != null, 'AppSettingsScope not found in widget tree');
+    return scope!.notifier!;
+  }
+}

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -270,6 +270,16 @@ class ContactDatabase {
     return Sqflite.firstIntValue(result) ?? 0;
   }
 
+  Future<int> activeReminderCount() async {
+    final db = await database;
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) as c FROM reminders WHERE completedAt IS NULL AND remindAt >= ?',
+      [now],
+    );
+    return Sqflite.firstIntValue(result) ?? 0;
+  }
+
   // ================= Notes =================
 
   Future<int> insertNote(Note note) async {

--- a/lib/services/push_notifications.dart
+++ b/lib/services/push_notifications.dart
@@ -12,6 +12,13 @@ class PushNotifications {
 
   static bool _initialized = false;
   static bool _tzReady = false;
+  static bool _enabled = true;
+
+  static void setEnabled(bool value) {
+    _enabled = value;
+  }
+
+  static bool get isEnabled => _enabled;
 
   static const AndroidNotificationDetails _androidDetails =
   AndroidNotificationDetails(
@@ -88,6 +95,7 @@ class PushNotifications {
     required String title,
     required String body,
   }) async {
+    if (!_enabled) return;
     await ensureInitialized();
     try {
       await _plugin.show(id, title, body, _details);
@@ -104,6 +112,7 @@ class PushNotifications {
     required String body,
     bool exact = true, // для Android: точное ли срабатывание
   }) async {
+    if (!_enabled) return;
     await ensureInitialized();
     await _ensureTimeZone();
 
@@ -132,6 +141,7 @@ class PushNotifications {
     required String body,
     bool exact = false,
   }) async {
+    if (!_enabled) return;
     await ensureInitialized();
     await _ensureTimeZone();
 
@@ -171,6 +181,7 @@ class PushNotifications {
     required String body,
     bool exact = false,
   }) async {
+    if (!_enabled) return;
     await ensureInitialized();
     await _ensureTimeZone();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   flutter_local_notifications: ^17.2.1
   timezone: ^0.9.4
   flutter_timezone: ^3.0.0
+  shared_preferences: ^2.2.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add persisted application settings to drive theme mode and notification toggles
- rebuild the theme and notification settings screens with interactive controls and visual feedback, including the radial transition effect
- simplify placeholder content for the privacy policy and user agreement screens and update the settings list with icons

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dac6d79bb48328b9575842beb1cebf