### PR TITLE
Add embedded web views for policy and agreement screens

### DIFF
--- a/lib/screens/privacy_policy_screen.dart
+++ b/lib/screens/privacy_policy_screen.dart
@@ -1,20 +1,50 @@
 import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
-class PrivacyPolicyScreen extends StatelessWidget {
+class PrivacyPolicyScreen extends StatefulWidget {
   const PrivacyPolicyScreen({super.key});
+
+  @override
+  State<PrivacyPolicyScreen> createState() => _PrivacyPolicyScreenState();
+}
+
+class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
+  late final WebViewController _controller;
+  double _progress = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onProgress: (progress) {
+            setState(() {
+              _progress = progress / 100;
+            });
+          },
+        ),
+      )
+      ..loadRequest(
+        Uri.parse('https://privacytouchnotebook.netlify.app/'),
+      );
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Политика конфиденциальности')),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text(
-            'Текст политики конфиденциальности появится здесь позже.',
-            textAlign: TextAlign.center,
+      body: Column(
+        children: [
+          if (_progress < 1)
+            LinearProgressIndicator(
+              value: _progress,
+            ),
+          Expanded(
+            child: WebViewWidget(controller: _controller),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/lib/screens/user_agreement_screen.dart
+++ b/lib/screens/user_agreement_screen.dart
@@ -1,20 +1,50 @@
 import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
-class UserAgreementScreen extends StatelessWidget {
+class UserAgreementScreen extends StatefulWidget {
   const UserAgreementScreen({super.key});
+
+  @override
+  State<UserAgreementScreen> createState() => _UserAgreementScreenState();
+}
+
+class _UserAgreementScreenState extends State<UserAgreementScreen> {
+  late final WebViewController _controller;
+  double _progress = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onProgress: (progress) {
+            setState(() {
+              _progress = progress / 100;
+            });
+          },
+        ),
+      )
+      ..loadRequest(
+        Uri.parse('https://eulatouchnotebook.netlify.app/'),
+      );
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Пользовательское соглашение')),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text(
-            'Раздел пользовательского соглашения находится в разработке.',
-            textAlign: TextAlign.center,
+      body: Column(
+        children: [
+          if (_progress < 1)
+            LinearProgressIndicator(
+              value: _progress,
+            ),
+          Expanded(
+            child: WebViewWidget(controller: _controller),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   timezone: ^0.9.4
   flutter_timezone: ^3.0.0
   shared_preferences: ^2.2.3
+  webview_flutter: ^4.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- embed the privacy policy screen as an in-app web view pointing to the production policy page
- embed the user agreement screen as an in-app web view pointing to the live agreement content
- add the webview_flutter dependency to support displaying the remote pages

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dae1bcd65c8328a20f20a850effe2d