### PR TITLE
Align social pickers across screens

### DIFF
--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -569,6 +569,17 @@ class _AddContactScreenState extends State<AddContactScreen> {
     FocusScope.of(context).requestFocus(_focusSocial);
     setState(() => _socialOpen = true);
 
+    const options = [
+      'Telegram',
+      'VK',
+      'Instagram',
+      'Facebook',
+      'WhatsApp',
+      'TikTok',
+      'Одноклассники',
+      'Twitter',
+    ];
+
     final result = await showModalBottomSheet<String>(
       context: context,
       showDragHandle: true,
@@ -583,14 +594,14 @@ class _AddContactScreenState extends State<AddContactScreen> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  ListTile(leading: _brandIcon('Telegram'), title: const Text('Telegram'), onTap: () => Navigator.pop(context, 'Telegram')),
-                  ListTile(leading: _brandIcon('VK'), title: const Text('VK'), onTap: () => Navigator.pop(context, 'VK')),
-                  ListTile(leading: _brandIcon('Instagram'), title: const Text('Instagram'), onTap: () => Navigator.pop(context, 'Instagram')),
-                  ListTile(leading: _brandIcon('Facebook'), title: const Text('Facebook'), onTap: () => Navigator.pop(context, 'Facebook')),
-                  ListTile(leading: _brandIcon('WhatsApp'), title: const Text('WhatsApp'), onTap: () => Navigator.pop(context, 'WhatsApp')),
-                  ListTile(leading: _brandIcon('TikTok'), title: const Text('TikTok'), onTap: () => Navigator.pop(context, 'TikTok')),
-                  ListTile(leading: _brandIcon('Одноклассники'), title: const Text('Одноклассники'), onTap: () => Navigator.pop(context, 'Одноклассники')),
-                  ListTile(leading: _brandIcon('Twitter'), title: const Text('Twitter'), onTap: () => Navigator.pop(context, 'Twitter')),
+                  for (var i = 0; i < options.length; i++) ...[
+                    if (i > 0) const Divider(height: 0),
+                    ListTile(
+                      leading: _brandIcon(options[i]),
+                      title: Text(options[i]),
+                      onTap: () => Navigator.pop(context, options[i]),
+                    ),
+                  ],
                 ],
               ),
             ),

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1594,6 +1594,17 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
     FocusScope.of(context).requestFocus(_focusSocial);
     setState(() => _socialOpen = true);
 
+    const options = [
+      'Telegram',
+      'VK',
+      'Instagram',
+      'Facebook',
+      'WhatsApp',
+      'TikTok',
+      'Одноклассники',
+      'Twitter',
+    ];
+
     final result = await showModalBottomSheet<String>(
       context: context,
       showDragHandle: true,
@@ -1604,28 +1615,35 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
       clipBehavior: Clip.antiAlias,
       builder: (context) {
         final maxH = MediaQuery.of(context).size.height * 0.8;
-        final items = [
-          'Telegram','VK','Instagram','Facebook','WhatsApp','TikTok','Одноклассники','Twitter',
-        ];
-        return _sheetWrap(
-          title: 'Соцсеть',
-          child: ConstrainedBox(
-            constraints: BoxConstraints(maxHeight: maxH),
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  for (int i = 0; i < items.length; i++)
-                    _radioRow<String>(
-                      value: items[i],
-                      groupValue: _socialType,
-                      title: items[i],
-                      leading: _brandIcon(items[i]),
-                      onSelect: () => Navigator.pop(context, items[i]),
-                      isLast: i == items.length - 1,
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.only(left: 16, right: 16, bottom: 16),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: maxH),
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                      child: Text(
+                        'Соцсеть',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                      ),
                     ),
-                ],
+                    const Divider(height: 1),
+                    for (var i = 0; i < options.length; i++) ...[
+                      if (i > 0) const Divider(height: 0),
+                      ListTile(
+                        leading: _brandIcon(options[i]),
+                        title: Text(options[i]),
+                        onTap: () => Navigator.pop(context, options[i]),
+                      ),
+                    ],
+                  ],
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- align the social network picker bottom sheets on the add and contact detail screens
- show the same set of social network options with brand icons and add separators between rows

## Testing
- flutter analyze *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daebe635608328af9b7715a98908a5