### PR TITLE
Remove Facebook, Instagram, and Twitter from social pickers

### DIFF
--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -356,12 +356,9 @@ class _AddContactScreenState extends State<AddContactScreen> {
   static const Map<String, String> _brandSlug = {
     'Telegram': 'telegram',
     'VK': 'vk',
-    'Instagram': 'instagram',
     'WhatsApp': 'whatsapp',
     'TikTok': 'tiktok',
     'Одноклассники': 'odnoklassniki',
-    'Facebook': 'facebook',
-    'Twitter': 'twitterx',
     'X': 'twitterx',
   };
 
@@ -572,12 +569,9 @@ class _AddContactScreenState extends State<AddContactScreen> {
     const options = [
       'Telegram',
       'VK',
-      'Instagram',
-      'Facebook',
       'WhatsApp',
       'TikTok',
       'Одноклассники',
-      'Twitter',
     ];
 
     final result = await showModalBottomSheet<String>(

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -717,12 +717,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
   static const Map<String, String> _brandSlug = {
     'Telegram': 'telegram',
     'VK': 'vk',
-    'Instagram': 'instagram',
     'WhatsApp': 'whatsapp',
     'TikTok': 'tiktok',
     'Одноклассники': 'odnoklassniki',
-    'Facebook': 'facebook',
-    'Twitter': 'twitterx',
     'X': 'twitterx',
   };
 
@@ -1597,12 +1594,9 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
     const options = [
       'Telegram',
       'VK',
-      'Instagram',
-      'Facebook',
       'WhatsApp',
       'TikTok',
       'Одноклассники',
-      'Twitter',
     ];
 
     final result = await showModalBottomSheet<String>(


### PR DESCRIPTION
## Summary
- remove Facebook, Instagram, and Twitter entries from the social network pickers on the add contact screen
- remove the same social networks from the contact details screen picker and associated icon map

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dafc394b1083289bbfa91fc3943af7