### PR TITLE
Add offline policy fallbacks for WebView screens

### DIFF
--- a/assets/policies/privacy_policy.html
+++ b/assets/policies/privacy_policy.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Политика конфиденциальности</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+      color: #1f2933;
+      padding: 16px;
+      background-color: #ffffff;
+    }
+    h1, h2 {
+      color: #111827;
+    }
+    a {
+      color: #2563eb;
+    }
+  </style>
+</head>
+<body>
+  <h1>Политика конфиденциальности Touch Notebook</h1>
+  <p>
+    Данная локальная версия политики конфиденциальности предназначена для
+    использования в офлайн-режиме. Она содержит ключевые положения о том,
+    какие данные собирает приложение, как они используются и какие права
+    имеют пользователи.
+  </p>
+  <h2>Сбор и использование данных</h2>
+  <p>
+    Мы обрабатываем только те данные, которые необходимы для обеспечения
+    работоспособности приложения и улучшения пользовательского опыта.
+    Подробная информация доступна в онлайн-версии политики по адресу
+    <a href="https://privacytouchnotebook.netlify.app/">privacytouchnotebook.netlify.app</a>.
+  </p>
+  <h2>Права пользователей</h2>
+  <p>
+    Вы вправе запросить доступ, исправление или удаление ваших персональных
+    данных. Для связи с нами напишите на электронную почту
+    <a href="mailto:support@touchnotebook.ru">support@touchnotebook.ru</a>.
+  </p>
+  <p>
+    При появлении подключения к интернету приложение автоматически загрузит
+    актуальную онлайн-версию документа.
+  </p>
+</body>
+</html>

--- a/assets/policies/user_agreement.html
+++ b/assets/policies/user_agreement.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Пользовательское соглашение</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+      color: #1f2933;
+      padding: 16px;
+      background-color: #ffffff;
+    }
+    h1, h2 {
+      color: #111827;
+    }
+    ul {
+      padding-left: 20px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Пользовательское соглашение Touch Notebook</h1>
+  <p>
+    Эта локальная версия соглашения доступна, когда устройство находится в
+    офлайн-режиме. Она описывает ключевые правила использования приложения и
+    обязанности сторон.
+  </p>
+  <h2>Основные условия</h2>
+  <ul>
+    <li>Пользователь обязуется использовать приложение в соответствии с законами РФ.</li>
+    <li>Разработчик предоставляет приложение «как есть» и не несет ответственности за непрямые убытки.</li>
+    <li>Подробные условия размещены в онлайн-версии соглашения.</li>
+  </ul>
+  <p>
+    Актуальную редакцию можно найти по адресу
+    <a href="https://eulatouchnotebook.netlify.app/">eulatouchnotebook.netlify.app</a>.
+  </p>
+  <p>
+    При восстановлении интернет-соединения приложение загрузит онлайн-версию
+    автоматически.
+  </p>
+</body>
+</html>

--- a/lib/screens/privacy_policy_screen.dart
+++ b/lib/screens/privacy_policy_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show InternetAddress, SocketException;
+
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -9,8 +11,13 @@ class PrivacyPolicyScreen extends StatefulWidget {
 }
 
 class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
+  static const _remoteUrl = 'https://privacytouchnotebook.netlify.app/';
+  static const _localAssetPath = 'assets/policies/privacy_policy.html';
+
   late final WebViewController _controller;
   double _progress = 0;
+  bool _hasError = false;
+  String? _errorDescription;
 
   @override
   void initState() {
@@ -20,15 +27,77 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
       ..setNavigationDelegate(
         NavigationDelegate(
           onProgress: (progress) {
+            if (!mounted) {
+              return;
+            }
             setState(() {
               _progress = progress / 100;
             });
           },
+          onWebResourceError: (error) {
+            if (!mounted) {
+              return;
+            }
+            setState(() {
+              _hasError = true;
+              _errorDescription = error.description;
+              _progress = 1;
+            });
+            _controller.loadFlutterAsset(_localAssetPath);
+          },
         ),
-      )
-      ..loadRequest(
-        Uri.parse('https://privacytouchnotebook.netlify.app/'),
       );
+
+    _loadInitialContent();
+  }
+
+  Future<void> _loadInitialContent() async {
+    await _controller.loadFlutterAsset(_localAssetPath);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _progress = 1;
+    });
+    await _loadRemoteContent();
+  }
+
+  Future<void> _loadRemoteContent() async {
+    setState(() {
+      _hasError = false;
+      _errorDescription = null;
+      _progress = 0;
+    });
+
+    final hasConnection = await _hasNetworkConnection();
+    if (!mounted) {
+      return;
+    }
+
+    if (!hasConnection) {
+      setState(() {
+        _hasError = true;
+        _errorDescription =
+            'Не удалось подключиться к интернету. Отображается офлайн-версия.';
+        _progress = 1;
+      });
+      return;
+    }
+
+    await _controller.loadRequest(Uri.parse(_remoteUrl));
+  }
+
+  Future<bool> _hasNetworkConnection() async {
+    try {
+      final result = await InternetAddress.lookup('example.com');
+      return result.isNotEmpty && result.first.rawAddress.isNotEmpty;
+    } on SocketException {
+      return false;
+    }
+  }
+
+  Future<void> _retryLoadRemote() async {
+    await _loadRemoteContent();
   }
 
   @override
@@ -42,7 +111,38 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
               value: _progress,
             ),
           Expanded(
-            child: WebViewWidget(controller: _controller),
+            child: Stack(
+              children: [
+                WebViewWidget(controller: _controller),
+                if (_hasError)
+                  Positioned.fill(
+                    child: Container(
+                      color: Theme.of(context).colorScheme.background.withOpacity(0.95),
+                      padding: const EdgeInsets.symmetric(horizontal: 24),
+                      child: Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(Icons.wifi_off, size: 48),
+                            const SizedBox(height: 16),
+                            Text(
+                              _errorDescription ??
+                                  'Не удалось загрузить онлайн-версию документа.',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodyLarge,
+                            ),
+                            const SizedBox(height: 24),
+                            ElevatedButton(
+                              onPressed: _retryLoadRemote,
+                              child: const Text('Повторить'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/screens/user_agreement_screen.dart
+++ b/lib/screens/user_agreement_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show InternetAddress, SocketException;
+
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -9,8 +11,13 @@ class UserAgreementScreen extends StatefulWidget {
 }
 
 class _UserAgreementScreenState extends State<UserAgreementScreen> {
+  static const _remoteUrl = 'https://eulatouchnotebook.netlify.app/';
+  static const _localAssetPath = 'assets/policies/user_agreement.html';
+
   late final WebViewController _controller;
   double _progress = 0;
+  bool _hasError = false;
+  String? _errorDescription;
 
   @override
   void initState() {
@@ -20,15 +27,77 @@ class _UserAgreementScreenState extends State<UserAgreementScreen> {
       ..setNavigationDelegate(
         NavigationDelegate(
           onProgress: (progress) {
+            if (!mounted) {
+              return;
+            }
             setState(() {
               _progress = progress / 100;
             });
           },
+          onWebResourceError: (error) {
+            if (!mounted) {
+              return;
+            }
+            setState(() {
+              _hasError = true;
+              _errorDescription = error.description;
+              _progress = 1;
+            });
+            _controller.loadFlutterAsset(_localAssetPath);
+          },
         ),
-      )
-      ..loadRequest(
-        Uri.parse('https://eulatouchnotebook.netlify.app/'),
       );
+
+    _loadInitialContent();
+  }
+
+  Future<void> _loadInitialContent() async {
+    await _controller.loadFlutterAsset(_localAssetPath);
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _progress = 1;
+    });
+    await _loadRemoteContent();
+  }
+
+  Future<void> _loadRemoteContent() async {
+    setState(() {
+      _hasError = false;
+      _errorDescription = null;
+      _progress = 0;
+    });
+
+    final hasConnection = await _hasNetworkConnection();
+    if (!mounted) {
+      return;
+    }
+
+    if (!hasConnection) {
+      setState(() {
+        _hasError = true;
+        _errorDescription =
+            'Не удалось подключиться к интернету. Отображается офлайн-версия.';
+        _progress = 1;
+      });
+      return;
+    }
+
+    await _controller.loadRequest(Uri.parse(_remoteUrl));
+  }
+
+  Future<bool> _hasNetworkConnection() async {
+    try {
+      final result = await InternetAddress.lookup('example.com');
+      return result.isNotEmpty && result.first.rawAddress.isNotEmpty;
+    } on SocketException {
+      return false;
+    }
+  }
+
+  Future<void> _retryLoadRemote() async {
+    await _loadRemoteContent();
   }
 
   @override
@@ -42,7 +111,38 @@ class _UserAgreementScreenState extends State<UserAgreementScreen> {
               value: _progress,
             ),
           Expanded(
-            child: WebViewWidget(controller: _controller),
+            child: Stack(
+              children: [
+                WebViewWidget(controller: _controller),
+                if (_hasError)
+                  Positioned.fill(
+                    child: Container(
+                      color: Theme.of(context).colorScheme.background.withOpacity(0.95),
+                      padding: const EdgeInsets.symmetric(horizontal: 24),
+                      child: Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(Icons.wifi_off, size: 48),
+                            const SizedBox(height: 16),
+                            Text(
+                              _errorDescription ??
+                                  'Не удалось загрузить онлайн-версию документа.',
+                              textAlign: TextAlign.center,
+                              style: Theme.of(context).textTheme.bodyLarge,
+                            ),
+                            const SizedBox(height: 24),
+                            ElevatedButton(
+                              onPressed: _retryLoadRemote,
+                              child: const Text('Повторить'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           ),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,8 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+    - assets/policies/privacy_policy.html
+    - assets/policies/user_agreement.html
 
 
 flutter_launcher_icons:


### PR DESCRIPTION
## Summary
- add local HTML versions of the privacy policy and user agreement and register them as Flutter assets
- load the offline copies first in the policy and agreement WebViews, then replace them with the remote pages when connectivity is available
- surface a retry overlay when the remote content fails so users understand they are seeing the offline version

## Testing
- not run (Flutter SDK not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dafd0c245c8328bcec37606c458bd8