### PR TITLE
Add MAX social network option to contact sheets

### DIFF
--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -359,6 +359,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
     'WhatsApp': 'whatsapp',
     'TikTok': 'tiktok',
     'Одноклассники': 'odnoklassniki',
+    'MAX': 'MAX',
   };
 
   String _brandAssetPath(String value) {
@@ -571,6 +572,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
       'WhatsApp',
       'TikTok',
       'Одноклассники',
+      'MAX',
     ];
 
     final result = await showModalBottomSheet<String>(

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -720,6 +720,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
     'WhatsApp': 'whatsapp',
     'TikTok': 'tiktok',
     'Одноклассники': 'odnoklassniki',
+    'MAX': 'MAX',
   };
 
   String _brandAssetPath(String value) {
@@ -1599,6 +1600,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
       'WhatsApp',
       'TikTok',
       'Одноклассники',
+      'MAX',
     ];
 
     final result = await showModalBottomSheet<String>(


### PR DESCRIPTION
## Summary
- add MAX social network icon mapping for add and detail contact screens
- include MAX in the social network bottom sheet options so it can be selected

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db040b31788328af68f461ec4ecc42