### PR TITLE
Prevent duplicate phone numbers and tighten contact validation

### DIFF
--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 import 'package:mask_text_input_formatter/mask_text_input_formatter.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:characters/characters.dart';
+import 'package:flutter/services.dart';
 
 import '../models/contact.dart';
 import '../services/contact_database.dart';
@@ -737,6 +738,16 @@ class _AddContactScreenState extends State<AddContactScreen> {
     // нормализуем телефон (в БД — только цифры)
     final rawPhone = _phoneMask.getUnmaskedText();
 
+    final duplicate = await ContactDatabase.instance.contactByPhone(rawPhone);
+    if (duplicate != null) {
+      if (mounted) {
+        showErrorBanner('Контакт с таким телефоном уже существует');
+        await _ensureVisible(_phoneKey);
+        setState(() => _saving = false);
+      }
+      return;
+    }
+
     final contact = Contact(
       name: _nameController.text.trim(),
       birthDate: _birthDate,
@@ -1005,6 +1016,7 @@ class _AddContactScreenState extends State<AddContactScreen> {
                         maxLines: 1,
                         autofillHints: const [AutofillHints.name],
                         textInputAction: TextInputAction.next,
+                        inputFormatters: const [FilteringTextInputFormatter.deny(RegExp(r'[0-9]'))],
                         decoration: _outlinedDec(
                           Theme.of(context),
                           label: 'ФИО*',

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -178,6 +178,20 @@ class ContactDatabase {
     return id;
   }
 
+  Future<Contact?> contactByPhone(String phone, {int? excludeId}) async {
+    final db = await database;
+    final args = excludeId != null ? [phone, excludeId] : [phone];
+    final where = excludeId != null ? 'phone = ? AND id != ?' : 'phone = ?';
+    final maps = await db.query(
+      'contacts',
+      where: where,
+      whereArgs: args,
+      limit: 1,
+    );
+    if (maps.isEmpty) return null;
+    return Contact.fromMap(maps.first);
+  }
+
   Future<List<Contact>> contactsByCategory(String category) async {
     final db = await database;
     final now = DateTime.now().millisecondsSinceEpoch;


### PR DESCRIPTION
## Summary
- prevent saving contacts with duplicate phone numbers during creation and editing using a new database lookup
- standardize email validation and normalize stored values when editing contacts
- disallow digits in the full name fields on contact creation and detail screens

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc0a6b64088328951925f5464a5727