### PR TITLE
Improve validation UX when saving contacts

### DIFF
--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -178,6 +178,20 @@ class ContactDatabase {
     return id;
   }
 
+  Future<Contact?> contactByPhone(String phone, {int? excludeId}) async {
+    final db = await database;
+    final args = excludeId != null ? [phone, excludeId] : [phone];
+    final where = excludeId != null ? 'phone = ? AND id != ?' : 'phone = ?';
+    final maps = await db.query(
+      'contacts',
+      where: where,
+      whereArgs: args,
+      limit: 1,
+    );
+    if (maps.isEmpty) return null;
+    return Contact.fromMap(maps.first);
+  }
+
   Future<List<Contact>> contactsByCategory(String category) async {
     final db = await database;
     final now = DateTime.now().millisecondsSinceEpoch;


### PR DESCRIPTION
## Summary
- let the add-contact buttons trigger validation feedback instead of staying disabled by showing banners, scrolling to the missing fields, and reusing the save gate while loading
- apply the same guided validation flow on the contact detail editor, including expanding the additional section, scrolling, and focusing fields with errors
- autovalidate email fields after interaction on both screens so malformed addresses are surfaced immediately

## Testing
- Not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc0a6b64088328951925f5464a5727