### PR TITLE
Show all missing required fields and highlight duplicate phones

### DIFF
--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -178,6 +178,20 @@ class ContactDatabase {
     return id;
   }
 
+  Future<Contact?> contactByPhone(String phone, {int? excludeId}) async {
+    final db = await database;
+    final args = excludeId != null ? [phone, excludeId] : [phone];
+    final where = excludeId != null ? 'phone = ? AND id != ?' : 'phone = ?';
+    final maps = await db.query(
+      'contacts',
+      where: where,
+      whereArgs: args,
+      limit: 1,
+    );
+    if (maps.isEmpty) return null;
+    return Contact.fromMap(maps.first);
+  }
+
   Future<List<Contact>> contactsByCategory(String category) async {
     final db = await database;
     final now = DateTime.now().millisecondsSinceEpoch;


### PR DESCRIPTION
## Summary
- aggregate required field validation messaging so saving shows every missing required field on both add and detail screens
- surface duplicate phone errors in the form field while resetting the flag when the number changes

## Testing
- Not run (flutter not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dc0a6b64088328951925f5464a5727