### PR TITLE
Handle duplicate phone alongside required field errors

### DIFF
--- a/lib/screens/add_contact_screen.dart
+++ b/lib/screens/add_contact_screen.dart
@@ -800,15 +800,45 @@ class _AddContactScreenState extends State<AddContactScreen> {
       addMissing('Дата добавления', _addedKey, focusNode: _focusAdded);
     }
 
+    Contact? duplicateContact;
+    if (_phoneValid) {
+      duplicateContact = await ContactDatabase.instance.contactByPhone(phoneDigits);
+      if (!mounted) return;
+    } else if (_duplicatePhone && mounted) {
+      setState(() => _duplicatePhone = false);
+    }
+
+    final issueMessages = <String>[];
+    GlobalKey? issueKey;
+    FocusNode? issueFocus;
+    var issueExpand = false;
+
     if (missingLabels.isNotEmpty) {
       final message = missingLabels.length == 1
           ? 'Заполните поле «${missingLabels.first}»'
           : 'Заполните поля: ${missingLabels.join(', ')}';
+      issueMessages.add(message);
+      issueKey = firstMissingKey;
+      issueFocus = firstMissingFocus;
+      issueExpand = firstMissingExpand;
+    }
+
+    if (mounted && _duplicatePhone != (duplicateContact != null)) {
+      setState(() => _duplicatePhone = duplicateContact != null);
+    }
+
+    if (duplicateContact != null) {
+      issueMessages.add('Контакт с таким телефоном уже существует');
+      issueKey ??= _phoneKey;
+      _formKey.currentState?.validate();
+    }
+
+    if (issueMessages.isNotEmpty) {
       await _showFieldIssue(
-        message: message,
-        targetKey: firstMissingKey,
-        focusNode: firstMissingFocus,
-        expandExtra: firstMissingExpand,
+        message: issueMessages.join('\n'),
+        targetKey: issueKey,
+        focusNode: issueFocus,
+        expandExtra: issueExpand,
       );
       return;
     }

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1882,15 +1882,48 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
       addMissing('Дата добавления', _addedKey, focusNode: _focusAdded);
     }
 
+    Contact? duplicateContact;
+    if (_phoneValid) {
+      duplicateContact = await ContactDatabase.instance.contactByPhone(
+        phoneDigits,
+        excludeId: _contact.id,
+      );
+      if (!mounted) return;
+    } else if (_duplicatePhone && mounted) {
+      setState(() => _duplicatePhone = false);
+    }
+
+    final issueMessages = <String>[];
+    GlobalKey? issueKey;
+    FocusNode? issueFocus;
+    var issueExpand = false;
+
     if (missingLabels.isNotEmpty) {
       final message = missingLabels.length == 1
           ? 'Заполните поле «${missingLabels.first}»'
           : 'Заполните поля: ${missingLabels.join(', ')}';
+      issueMessages.add(message);
+      issueKey = firstMissingKey;
+      issueFocus = firstMissingFocus;
+      issueExpand = firstMissingExpand;
+    }
+
+    if (mounted && _duplicatePhone != (duplicateContact != null)) {
+      setState(() => _duplicatePhone = duplicateContact != null);
+    }
+
+    if (duplicateContact != null) {
+      issueMessages.add('Контакт с таким телефоном уже существует');
+      issueKey ??= _phoneKey;
+      _formKey.currentState?.validate();
+    }
+
+    if (issueMessages.isNotEmpty) {
       await _showFieldIssue(
-        message: message,
-        targetKey: firstMissingKey,
-        focusNode: firstMissingFocus,
-        expandExtra: firstMissingExpand,
+        message: issueMessages.join('\n'),
+        targetKey: issueKey,
+        focusNode: issueFocus,
+        expandExtra: issueExpand,
       );
       return;
     }


### PR DESCRIPTION
## Summary
- allow duplicate phone validation to run alongside required field checks on the add contact form
- provide the same combined handling on the contact details edit form so both messages surface together

## Testing
- not run (flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e14e3c2cf4832899b4f6308c2d081b