### PR TITLE
Add reminder notification snooze actions and swipeable overlays

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1092,6 +1092,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
         whenLocal: saved.remindAt,
         title: 'Напоминание: ${_contact.name}',
         body: saved.text,
+        reminderActions: true,
       );
 
       await _loadReminders();
@@ -1127,6 +1128,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
         whenLocal: updated.remindAt,
         title: 'Напоминание: ${_contact.name}',
         body: updated.text,
+        reminderActions: true,
       );
 
       await _loadReminders();
@@ -2036,6 +2038,7 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
               whenLocal: reminder.remindAt,
               title: 'Напоминание: ${c.name}',
               body: reminder.text,
+              reminderActions: true,
             );
           }
         }

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -566,6 +566,7 @@ class _ContactListScreenState extends State<ContactListScreen> {
                 whenLocal: reminder.remindAt,
                 title: 'Напоминание: ${c.name}',
                 body: reminder.text,
+                reminderActions: true,
               );
             }
           }

--- a/lib/services/app_settings.dart
+++ b/lib/services/app_settings.dart
@@ -107,6 +107,7 @@ class AppSettings extends ChangeNotifier {
         whenLocal: reminder.remindAt,
         title: 'Напоминание: ${entry.contactName}',
         body: reminder.text,
+        reminderActions: true,
       );
     }
   }

--- a/lib/services/contact_database.dart
+++ b/lib/services/contact_database.dart
@@ -371,6 +371,18 @@ class ContactDatabase {
     return id;
   }
 
+  Future<Reminder?> reminderById(int id) async {
+    final db = await database;
+    final maps = await db.query(
+      'reminders',
+      where: 'id = ?',
+      whereArgs: [id],
+      limit: 1,
+    );
+    if (maps.isEmpty) return null;
+    return Reminder.fromMap(maps.first);
+  }
+
   Future<int> updateReminder(Reminder reminder) async {
     final db = await database;
     final rows = await db.update(

--- a/lib/services/push_notifications.dart
+++ b/lib/services/push_notifications.dart
@@ -4,6 +4,9 @@ import 'package:flutter_timezone/flutter_timezone.dart';              // NEW
 import 'package:timezone/data/latest_all.dart' as tz;               // NEW
 import 'package:timezone/timezone.dart' as tz;                      // NEW
 import 'package:flutter/material.dart' show TimeOfDay;
+
+import '../models/reminder.dart';
+import 'contact_database.dart';
 class PushNotifications {
   PushNotifications._();
 
@@ -14,47 +17,97 @@ class PushNotifications {
   static bool _tzReady = false;
   static bool _enabled = true;
 
+  static const _reminderPayloadPrefix = 'reminder:';
+  static const _reminderCategoryId = 'reminder_actions';
+  static const _snoozeActionId = 'reminder_snooze_1h';
+  static const _tomorrowActionId = 'reminder_tomorrow';
+
+  static final List<AndroidNotificationAction> _reminderAndroidActions =
+      <AndroidNotificationAction>[
+    AndroidNotificationAction(
+      _snoozeActionId,
+      'Отложить на час',
+      showsUserInterface: true,
+    ),
+    AndroidNotificationAction(
+      _tomorrowActionId,
+      'Напомнить завтра',
+      showsUserInterface: true,
+    ),
+  ];
+
+  static final DarwinNotificationCategory _darwinReminderCategory =
+      DarwinNotificationCategory(
+    _reminderCategoryId,
+    actions: <DarwinNotificationAction>[
+      DarwinNotificationAction.plain(
+        identifier: _snoozeActionId,
+        title: 'Отложить на час',
+        options: <DarwinNotificationActionOption>{
+          DarwinNotificationActionOption.foreground,
+        },
+      ),
+      DarwinNotificationAction.plain(
+        identifier: _tomorrowActionId,
+        title: 'Напомнить завтра',
+        options: <DarwinNotificationActionOption>{
+          DarwinNotificationActionOption.foreground,
+        },
+      ),
+    ],
+  );
+
+  static NotificationDetails _notificationDetails({
+    bool includeReminderActions = false,
+  }) {
+    final android = AndroidNotificationDetails(
+      'demo_push_channel',
+      'Демо уведомления',
+      channelDescription: 'Канал для тестовых push-уведомлений',
+      importance: Importance.max,
+      priority: Priority.high,
+      actions: includeReminderActions ? _reminderAndroidActions : null,
+    );
+
+    final darwin = DarwinNotificationDetails(
+      categoryIdentifier:
+          includeReminderActions ? _reminderCategoryId : null,
+    );
+
+    return NotificationDetails(
+      android: android,
+      iOS: darwin,
+      macOS: darwin,
+    );
+  }
+
   static void setEnabled(bool value) {
     _enabled = value;
   }
 
   static bool get isEnabled => _enabled;
 
-  static const AndroidNotificationDetails _androidDetails =
-  AndroidNotificationDetails(
-    'demo_push_channel',
-    'Демо уведомления',
-    channelDescription: 'Канал для тестовых push-уведомлений',
-    importance: Importance.max,
-    priority: Priority.high,
-  );
-
-  static const DarwinNotificationDetails _darwinDetails =
-  DarwinNotificationDetails();
-
-  static const NotificationDetails _details = NotificationDetails(
-    android: _androidDetails,
-    iOS: _darwinDetails,
-    macOS: _darwinDetails,
-  );
-
   static Future<void> ensureInitialized() async {
     if (_initialized) return;
 
     const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
-    const darwinInit = DarwinInitializationSettings(
+    final darwinInit = DarwinInitializationSettings(
       requestAlertPermission: true,
       requestBadgePermission: true,
       requestSoundPermission: true,
+      notificationCategories: {_darwinReminderCategory},
     );
 
-    const settings = InitializationSettings(
+    final settings = InitializationSettings(
       android: androidInit,
       iOS: darwinInit,
       macOS: darwinInit,
     );
 
-    await _plugin.initialize(settings);
+    await _plugin.initialize(
+      settings,
+      onDidReceiveNotificationResponse: _onNotificationResponse,
+    );
 
     // Android 13+: запрос разрешения на показ уведомлений
     final androidImplementation = _plugin
@@ -94,11 +147,18 @@ class PushNotifications {
     required int id,
     required String title,
     required String body,
+    String? payload,
   }) async {
     if (!_enabled) return;
     await ensureInitialized();
     try {
-      await _plugin.show(id, title, body, _details);
+      await _plugin.show(
+        id,
+        title,
+        body,
+        _notificationDetails(),
+        payload: payload,
+      );
     } catch (e, s) {
       if (kDebugMode) print('Failed to show notification: $e\n$s');
     }
@@ -111,25 +171,33 @@ class PushNotifications {
     required String title,
     required String body,
     bool exact = true, // для Android: точное ли срабатывание
+    String? payload,
+    bool reminderActions = false,
   }) async {
     if (!_enabled) return;
     await ensureInitialized();
     await _ensureTimeZone();
 
     final scheduled = tz.TZDateTime.from(whenLocal, tz.local);
+    final details =
+        _notificationDetails(includeReminderActions: reminderActions);
+    final effectivePayload = reminderActions
+        ? (payload ?? '$_reminderPayloadPrefix$id')
+        : payload;
 
     await _plugin.zonedSchedule(
       id,
       title,
       body,
       scheduled,
-      _details,
+      details,
       androidScheduleMode: exact
           ? AndroidScheduleMode.exactAllowWhileIdle
           : AndroidScheduleMode.inexact,
       uiLocalNotificationDateInterpretation:
       UILocalNotificationDateInterpretation.absoluteTime, // ⬅️ ДОБАВИТЬ
       // matchDateTimeComponents не указываем — одноразовое
+      payload: effectivePayload,
     );
   }
 
@@ -163,7 +231,7 @@ class PushNotifications {
       title,
       body,
       first,
-      _details,
+      _notificationDetails(),
       androidScheduleMode:
       exact ? AndroidScheduleMode.exactAllowWhileIdle : AndroidScheduleMode.inexact,
       matchDateTimeComponents: DateTimeComponents.time,
@@ -204,7 +272,7 @@ class PushNotifications {
       title,
       body,
       first,
-      _details,
+      _notificationDetails(),
       androidScheduleMode:
       exact ? AndroidScheduleMode.exactAllowWhileIdle : AndroidScheduleMode.inexact,
       matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime,
@@ -212,6 +280,90 @@ class PushNotifications {
       UILocalNotificationDateInterpretation.absoluteTime, // ⬅️ ДОБАВИТЬ
     );
 
+  }
+
+  static Future<void> _onNotificationResponse(
+    NotificationResponse response,
+  ) async {
+    await handleNotificationResponse(response);
+  }
+
+  static Future<void> handleNotificationResponse(
+    NotificationResponse response,
+  ) async {
+    final payload = response.payload;
+    if (payload == null || !payload.startsWith(_reminderPayloadPrefix)) {
+      return;
+    }
+
+    if (response.notificationResponseType !=
+        NotificationResponseType.selectedNotificationAction) {
+      return;
+    }
+
+    final actionId = response.actionId;
+    if (actionId == null) return;
+
+    final reminderId =
+        int.tryParse(payload.substring(_reminderPayloadPrefix.length));
+    if (reminderId == null) return;
+
+    await _handleReminderAction(reminderId, actionId, response);
+  }
+
+  static Future<void> _handleReminderAction(
+    int reminderId,
+    String actionId,
+    NotificationResponse response,
+  ) async {
+    if (actionId != _snoozeActionId && actionId != _tomorrowActionId) {
+      return;
+    }
+
+    final reminder = await ContactDatabase.instance.reminderById(reminderId);
+    if (reminder == null) return;
+
+    final now = DateTime.now();
+    late final DateTime newRemindAt;
+
+    if (actionId == _snoozeActionId) {
+      final base = reminder.remindAt.isAfter(now) ? reminder.remindAt : now;
+      newRemindAt = base.add(const Duration(hours: 1));
+    } else {
+      final original = reminder.remindAt;
+      final tomorrow = now.add(const Duration(days: 1));
+      newRemindAt = DateTime(
+        tomorrow.year,
+        tomorrow.month,
+        tomorrow.day,
+        original.hour,
+        original.minute,
+        original.second,
+        original.millisecond,
+        original.microsecond,
+      );
+
+      if (!newRemindAt.isAfter(now)) {
+        newRemindAt = now.add(const Duration(days: 1));
+      }
+    }
+
+    final updated = reminder.copyWith(
+      remindAt: newRemindAt,
+      completedAt: null,
+    );
+
+    await ContactDatabase.instance.updateReminder(updated);
+
+    final title = response.notification?.title ?? 'Напоминание';
+    await scheduleOneTime(
+      id: reminderId,
+      whenLocal: newRemindAt,
+      title: title,
+      body: reminder.text,
+      payload: response.payload,
+      reminderActions: true,
+    );
   }
 
   static Future<void> cancel(int id) async {

--- a/lib/widgets/system_notifications.dart
+++ b/lib/widgets/system_notifications.dart
@@ -30,17 +30,24 @@ OverlaySupportEntry showSystemNotification(
             )
           : null;
 
-      return _SystemNotificationSurface(
+      final surface = _SystemNotificationSurface(
         backgroundColor: colors.background,
         textColor: colors.foreground,
         icon: icon,
         iconColor: colors.iconColor,
-        content: Text(
-          message,
-          maxLines: 3,
-          overflow: TextOverflow.ellipsis,
-        ),
+        content: _NotificationMessage(message: message),
         action: action,
+      );
+
+      final dismissibleKey = entry != null ? ValueKey(entry) : UniqueKey();
+
+      return Dismissible(
+        key: dismissibleKey,
+        direction: DismissDirection.horizontal,
+        onDismissed: (_) {
+          entry?.dismiss();
+        },
+        child: surface,
       );
     },
     duration: duration,
@@ -341,6 +348,54 @@ class _SystemNotificationSurface extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _NotificationMessage extends StatelessWidget {
+  final String message;
+
+  const _NotificationMessage({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final lines = message
+        .split(RegExp(r'\r?\n'))
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty)
+        .toList(growable: false);
+
+    if (lines.length <= 1) {
+      final text = lines.isEmpty ? '' : lines.first;
+      return Text(
+        text,
+        maxLines: 4,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (var i = 0; i < lines.length; i++)
+          Padding(
+            padding: EdgeInsets.only(bottom: i == lines.length - 1 ? 0 : 4),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.only(top: 2),
+                  child: Text('•'),
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(lines[i]),
+                ),
+              ],
+            ),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- make overlay banners swipe-to-dismiss and render multi-line messages with clearer bullet formatting
- add quick actions to reminder notifications to snooze or move to tomorrow while updating the existing reminder
- reschedule reminders with the new actions when creating, editing, or restoring reminders and expose a lookup helper in the database

## Testing
- Not run (flutter analyze) – `flutter` command is unavailable in the environment


------
https://chatgpt.com/codex/tasks/task_e_68e1576767b88328903a243aa6d99342