### PR TITLE
Add expandable notification shade content

### DIFF
--- a/lib/widgets/system_notifications.dart
+++ b/lib/widgets/system_notifications.dart
@@ -65,13 +65,19 @@ OverlaySupportEntry showSystemNotification(
         textColor: colors.foreground,
         icon: icon,
         iconColor: colors.iconColor,
-        content: Text(
-          message,
-          maxLines: 3,
-          overflow: TextOverflow.ellipsis,
+        contentBuilder: (context, expanded) => AnimatedSize(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInOut,
+          alignment: Alignment.topLeft,
+          child: Text(
+            message,
+            maxLines: expanded ? null : 3,
+            overflow: expanded ? TextOverflow.visible : TextOverflow.ellipsis,
+          ),
         ),
         action: action,
         extraActions: resolvedExtraActions,
+        allowContentExpansion: true,
       );
     },
     duration: duration,
@@ -136,7 +142,7 @@ OverlaySupportEntry showUndoBanner({
         textColor: colors.foreground,
         icon: icon,
         iconColor: colors.iconColor,
-        content: UndoCountdownContent(
+        contentBuilder: (context, expanded) => UndoCountdownContent(
           message: message,
           endTime: endTime,
           duration: duration,
@@ -154,6 +160,7 @@ OverlaySupportEntry showUndoBanner({
           ),
           child: Text(actionLabel),
         ),
+        allowContentExpansion: false,
       );
     },
     duration: duration,
@@ -303,22 +310,24 @@ class _CircularCountdownIndicator extends StatelessWidget {
 }
 
 class _SystemNotificationSurface extends StatefulWidget {
-  final Widget content;
+  final Widget Function(BuildContext context, bool expanded) contentBuilder;
   final IconData? icon;
   final Color? iconColor;
   final Color backgroundColor;
   final Color textColor;
   final Widget? action;
   final List<_SurfaceAction> extraActions;
+  final bool allowContentExpansion;
 
   const _SystemNotificationSurface({
-    required this.content,
+    required this.contentBuilder,
     required this.backgroundColor,
     required this.textColor,
     this.icon,
     this.iconColor,
     this.action,
     this.extraActions = const [],
+    this.allowContentExpansion = false,
   });
 
   @override
@@ -339,6 +348,9 @@ class _SystemNotificationSurfaceState extends State<_SystemNotificationSurface>
     final baseStyle = theme.textTheme.bodyMedium ?? const TextStyle(fontSize: 14);
     final textStyle = baseStyle.copyWith(color: widget.textColor);
     final hasExtraActions = widget.extraActions.isNotEmpty;
+    final canExpand = hasExtraActions || widget.allowContentExpansion;
+
+    final content = widget.contentBuilder(context, _expanded);
 
     final children = <Widget>[];
     if (widget.icon != null) {
@@ -346,18 +358,18 @@ class _SystemNotificationSurfaceState extends State<_SystemNotificationSurface>
         ..add(Icon(widget.icon, color: widget.iconColor ?? widget.textColor))
         ..add(const SizedBox(width: 12));
     }
-    children.add(Expanded(child: widget.content));
+    children.add(Expanded(child: content));
     if (widget.action != null) {
       children
         ..add(const SizedBox(width: 12))
         ..add(widget.action!);
     }
-    if (hasExtraActions) {
+    if (canExpand) {
       children
         ..add(const SizedBox(width: 8))
         ..add(IconButton(
           splashRadius: 20,
-          tooltip: _expanded ? 'Скрыть действия' : 'Показать действия',
+          tooltip: _expanded ? 'Свернуть уведомление' : 'Развернуть уведомление',
           onPressed: _toggleExpanded,
           icon: AnimatedRotation(
             duration: const Duration(milliseconds: 200),


### PR DESCRIPTION
## Summary
- allow system notifications to toggle between collapsed and expanded message states with an animated transition
- update the notification surface to drive both content and extra-action expansion from a shared toggle

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1869333e483289a838943104346ef