### PR TITLE
Enable expandable Android notifications

### DIFF
--- a/lib/services/push_notifications.dart
+++ b/lib/services/push_notifications.dart
@@ -41,13 +41,27 @@ class PushNotifications {
   static const DarwinNotificationDetails _darwinDetails =
   DarwinNotificationDetails();
 
-  static NotificationDetails _buildDetails({bool withReminderActions = false}) {
+  static NotificationDetails _buildDetails({
+    bool withReminderActions = false,
+    String? title,
+    String? body,
+  }) {
+    final styleInformation = (body != null && body.isNotEmpty)
+        ? BigTextStyleInformation(
+            body,
+            contentTitle: title,
+            htmlFormatBigText: true,
+            htmlFormatContentTitle: true,
+          )
+        : null;
+
     final androidDetails = AndroidNotificationDetails(
       'demo_push_channel',
       'Демо уведомления',
       channelDescription: 'Канал для тестовых push-уведомлений',
       importance: Importance.max,
       priority: Priority.high,
+      styleInformation: styleInformation,
       actions: withReminderActions
           ? const [
               AndroidNotificationAction(
@@ -142,7 +156,12 @@ class PushNotifications {
     if (!_enabled) return;
     await ensureInitialized();
     try {
-      await _plugin.show(id, title, body, _buildDetails());
+      await _plugin.show(
+        id,
+        title,
+        body,
+        _buildDetails(title: title, body: body),
+      );
     } catch (e, s) {
       if (kDebugMode) print('Failed to show notification: $e\n$s');
     }
@@ -169,7 +188,11 @@ class PushNotifications {
       title,
       body,
       scheduled,
-      _buildDetails(withReminderActions: withReminderActions),
+      _buildDetails(
+        withReminderActions: withReminderActions,
+        title: title,
+        body: body,
+      ),
       androidScheduleMode: exact
           ? AndroidScheduleMode.exactAllowWhileIdle
           : AndroidScheduleMode.inexact,
@@ -210,7 +233,7 @@ class PushNotifications {
       title,
       body,
       first,
-      _buildDetails(),
+      _buildDetails(title: title, body: body),
       androidScheduleMode:
       exact ? AndroidScheduleMode.exactAllowWhileIdle : AndroidScheduleMode.inexact,
       matchDateTimeComponents: DateTimeComponents.time,
@@ -251,7 +274,7 @@ class PushNotifications {
       title,
       body,
       first,
-      _buildDetails(),
+      _buildDetails(title: title, body: body),
       androidScheduleMode:
       exact ? AndroidScheduleMode.exactAllowWhileIdle : AndroidScheduleMode.inexact,
       matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime,


### PR DESCRIPTION
## Summary
- allow Android notifications to expand by using a big text style when a body is provided

## Testing
- flutter test *(fails: flutter not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e188b7f0048328b2df68ed4836cf70