### PR TITLE
Add about screen with share option

### DIFF
--- a/lib/screens/about_app_screen.dart
+++ b/lib/screens/about_app_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
+
+class AboutAppScreen extends StatelessWidget {
+  const AboutAppScreen({super.key});
+
+  static const _shareMessage =
+      'Попробуй приложение Touch NoteBook от Topskiy Vision Works!';
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('О приложении')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Touch NoteBook',
+                    style: textTheme.titleLarge,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Разработчик: Topskiy Vision Works',
+                    style: textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  const Text(
+                    'Touch NoteBook помогает управлять контактами, '
+                    'заметками и напоминаниями в едином приложении.',
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.share_outlined),
+              title: const Text('Поделиться приложением'),
+              onTap: () {
+                Share.share(_shareMessage);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'about_app_screen.dart';
 import 'notifications_settings_screen.dart';
 import 'privacy_policy_screen.dart';
 import 'theme_settings_screen.dart';
@@ -34,6 +35,11 @@ class SettingsScreen extends StatelessWidget {
             title: 'Пользовательское соглашение',
             icon: Icons.receipt_long_outlined,
             destination: UserAgreementScreen(),
+          ),
+          _SettingsCard(
+            title: 'О приложении',
+            icon: Icons.info_outline,
+            destination: AboutAppScreen(),
           ),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   flutter_timezone: ^3.0.0
   shared_preferences: ^2.2.3
   webview_flutter: ^4.7.0
+  share_plus: ^10.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add an "About app" page in settings that highlights the Topskiy Vision Works developer
- allow users to share the application directly from the about screen
- register the share_plus dependency required for sharing support

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e613c713e0832892d9ca8fb9ec19f6