### PR TITLE
Add app version info and circular reveal transitions

### DIFF
--- a/lib/screens/about_app_screen.dart
+++ b/lib/screens/about_app_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../widgets/app_version_list_tile.dart';
+
 class AboutAppScreen extends StatelessWidget {
   const AboutAppScreen({super.key});
 
@@ -36,10 +38,14 @@ class AboutAppScreen extends StatelessWidget {
                     'Touch NoteBook помогает управлять контактами, '
                     'заметками и напоминаниями в едином приложении.',
                   ),
+                  const SizedBox(height: 16),
+                  const Divider(height: 32),
+                  const AppVersionListTile(),
                 ],
               ),
             ),
           ),
+          const SizedBox(height: 12),
           Card(
             child: ListTile(
               leading: const Icon(Icons.share_outlined),

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -14,6 +14,7 @@ import '../models/note.dart';
 import '../models/reminder.dart';
 import '../services/contact_database.dart';
 import '../services/push_notifications.dart';
+import '../widgets/circular_reveal_route.dart';
 import '../widgets/system_notifications.dart';
 import 'notes_list_screen.dart';
 import 'add_note_screen.dart';
@@ -1045,12 +1046,13 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
     if (mounted) setState(() => _notes = notes);
   }
 
-  Future<void> _addNote() async {
+  Future<void> _addNote(BuildContext triggerContext) async {
     if (_contact.id == null) return;
-    final note = await Navigator.push<Note>(
-      context,
-      MaterialPageRoute(
+    final origin = CircularRevealPageRoute.originFromContext(triggerContext);
+    final note = await Navigator.of(triggerContext).push<Note>(
+      CircularRevealPageRoute<Note>(
         builder: (_) => AddNoteScreen(contactId: _contact.id!),
+        center: origin,
       ),
     );
     if (note != null) {
@@ -2816,10 +2818,14 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
                               textAlign: TextAlign.center,
                             ),
                             const SizedBox(height: 24),
-                            FilledButton.icon(
-                              onPressed: _contact.id == null ? null : _addNote,
-                              icon: const Icon(Icons.add),
-                              label: const Text('Добавить заметку'),
+                            Builder(
+                              builder: (buttonContext) => FilledButton.icon(
+                                onPressed: _contact.id == null
+                                    ? null
+                                    : () => _addNote(buttonContext),
+                                icon: const Icon(Icons.add),
+                                label: const Text('Добавить заметку'),
+                              ),
                             ),
                           ],
                         ),

--- a/lib/screens/contact_list_screen.dart
+++ b/lib/screens/contact_list_screen.dart
@@ -8,6 +8,7 @@ import '../models/contact.dart';
 import '../models/reminder.dart';
 import '../services/contact_database.dart';
 import '../services/push_notifications.dart';
+import '../widgets/circular_reveal_route.dart';
 import '../widgets/system_notifications.dart';
 import 'add_contact_screen.dart';
 import 'contact_details_screen.dart';
@@ -742,29 +743,26 @@ class _ContactListScreenState extends State<ContactListScreen> {
           ],
         ),
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () async {
-          final saved = await Navigator.push(
-            context,
-            PageRouteBuilder(
-              pageBuilder: (_, __, ___) => AddContactScreen(category: widget.category),
-              transitionsBuilder: (_, animation, __, child) {
-                const begin = Offset(0.0, 1.0);
-                const end = Offset.zero;
-                final tween = Tween(begin: begin, end: end).chain(CurveTween(curve: Curves.ease));
-                return SlideTransition(position: animation.drive(tween), child: child);
-              },
-            ),
-          );
-          if (saved == true) {
-            await _loadContacts(reset: true);
-            if (mounted) {
-              showSuccessBanner('Контакт сохранён');
+      floatingActionButton: Builder(
+        builder: (fabContext) => FloatingActionButton.extended(
+          onPressed: () async {
+            final origin = CircularRevealPageRoute.originFromContext(fabContext);
+            final saved = await Navigator.of(fabContext).push<bool>(
+              CircularRevealPageRoute<bool>(
+                builder: (_) => AddContactScreen(category: widget.category),
+                center: origin,
+              ),
+            );
+            if (saved == true) {
+              await _loadContacts(reset: true);
+              if (mounted) {
+                showSuccessBanner('Контакт сохранён');
+              }
             }
-          }
-        },
-        icon: const Icon(Icons.person_add),
-        label: const Text('Добавить контакт'),
+          },
+          icon: const Icon(Icons.person_add),
+          label: const Text('Добавить контакт'),
+        ),
       ),
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -16,6 +16,7 @@ import 'privacy_policy_screen.dart';
 import 'user_agreement_screen.dart';
 import '../services/app_settings.dart';
 import '../services/contact_database.dart';
+import '../widgets/circular_reveal_route.dart';
 
 
 /// ---------------------
@@ -23,7 +24,7 @@ import '../services/contact_database.dart';
 /// ---------------------
 abstract class R {
   static const appTitle = 'Touch NoteBook';
-  static const homeTitle = 'Главный экран';
+  static const homeTitle = 'Touch NoteBook';
   static const settings = 'Настройки';
   static const support = 'Поддержка';
   static const addContact = 'Добавить контакт';
@@ -355,11 +356,14 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
     }
   }
 
-  Future<void> _openAddContact(BuildContext context) async {
+  Future<void> _openAddContact(BuildContext triggerContext) async {
     if (!kIsWeb) HapticFeedback.selectionClick();
-    final saved = await Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => const AddContactScreen()),
+    final origin = CircularRevealPageRoute.originFromContext(triggerContext);
+    final saved = await Navigator.of(triggerContext).push<bool>(
+      CircularRevealPageRoute<bool>(
+        builder: (_) => const AddContactScreen(),
+        center: origin,
+      ),
     );
     if (saved == true && mounted) {
     }
@@ -547,14 +551,14 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
                     ? '${R.remindersOverview} ($totalReminders)'
                     : R.remindersOverview,
                 icon: _buildRemindersActionIcon(context, totalReminders),
-                onPressed: _openAllReminders,
+                onPressed: () => _openAllReminders(context),
               );
             },
           ),
         ],
       ),
       drawer: NavigationDrawer(
-        selectedIndex: 0, // всегда подсвечен "Главный экран"
+        selectedIndex: 0, // всегда подсвечен «Touch NoteBook»
         onDestinationSelected: (index) {
           Navigator.pop(context); // закрыли меню
           switch (index) {
@@ -765,11 +769,13 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
           ),
         ),
       ),
-      floatingActionButton: FloatingActionButton.extended(
-        tooltip: R.addContact,
-        onPressed: () => _openAddContact(context),
-        label: const Text(R.addContact),
-        icon: const Icon(Icons.person_add),
+      floatingActionButton: Builder(
+        builder: (fabContext) => FloatingActionButton.extended(
+          tooltip: R.addContact,
+          onPressed: () => _openAddContact(fabContext),
+          label: const Text(R.addContact),
+          icon: const Icon(Icons.person_add),
+        ),
       ),
     );
   }
@@ -824,10 +830,13 @@ class _HomeScreenState extends State<HomeScreen> with RestorationMixin {
     );
   }
 
-  void _openAllReminders() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => const AllRemindersScreen()),
+  void _openAllReminders(BuildContext triggerContext) {
+    final origin = CircularRevealPageRoute.originFromContext(triggerContext);
+    Navigator.of(triggerContext).push(
+      CircularRevealPageRoute<void>(
+        builder: (_) => const AllRemindersScreen(),
+        center: origin,
+      ),
     );
   }
 }

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -9,6 +9,7 @@ import 'package:overlay_support/overlay_support.dart';
 import '../models/contact.dart';
 import '../models/note.dart';
 import '../services/contact_database.dart';
+import '../widgets/circular_reveal_route.dart';
 import 'add_note_screen.dart';
 import 'note_details_screen.dart';
 import '../widgets/system_notifications.dart';
@@ -206,19 +207,13 @@ class _NotesListScreenState extends State<NotesListScreen> {
     });
   }
 
-  Future<void> _addNote() async {
+  Future<void> _addNote(BuildContext triggerContext) async {
     if (widget.contact.id == null) return;
-    final note = await Navigator.push<Note>(
-      context,
-      PageRouteBuilder(
-        pageBuilder: (_, __, ___) => AddNoteScreen(contactId: widget.contact.id!),
-        transitionsBuilder: (_, animation, __, child) {
-          const begin = Offset(0.0, 1.0);
-          const end = Offset.zero;
-          final tween =
-          Tween(begin: begin, end: end).chain(CurveTween(curve: Curves.ease));
-          return SlideTransition(position: animation.drive(tween), child: child);
-        },
+    final origin = CircularRevealPageRoute.originFromContext(triggerContext);
+    final note = await Navigator.of(triggerContext).push<Note>(
+      CircularRevealPageRoute<Note>(
+        builder: (_) => AddNoteScreen(contactId: widget.contact.id!),
+        center: origin,
       ),
     );
     if (note != null) {
@@ -427,9 +422,11 @@ class _NotesListScreenState extends State<NotesListScreen> {
         ],
       ),
       body: _buildList(data),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: _addNote,
-        label: const Text('Добавить заметку'),
+      floatingActionButton: Builder(
+        builder: (fabContext) => FloatingActionButton.extended(
+          onPressed: () => _addNote(fabContext),
+          label: const Text('Добавить заметку'),
+        ),
       ),
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'notifications_settings_screen.dart';
 import 'privacy_policy_screen.dart';
 import 'theme_settings_screen.dart';
 import 'user_agreement_screen.dart';
+import '../widgets/app_version_list_tile.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -40,6 +41,10 @@ class SettingsScreen extends StatelessWidget {
             title: 'О приложении',
             icon: Icons.info_outline,
             destination: AboutAppScreen(),
+          ),
+          SizedBox(height: 12),
+          Card(
+            child: AppVersionListTile(icon: Icons.tag_outlined),
           ),
         ],
       ),

--- a/lib/widgets/app_version_list_tile.dart
+++ b/lib/widgets/app_version_list_tile.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Универсальная плитка с информацией о версии приложения.
+class AppVersionListTile extends StatelessWidget {
+  const AppVersionListTile({super.key, this.icon});
+
+  /// Опциональная иконка слева от текста.
+  final IconData? icon;
+
+  static final Future<PackageInfo> _packageInfoFuture =
+      PackageInfo.fromPlatform();
+
+  @override
+  Widget build(BuildContext context) {
+    final IconData leadingIcon = icon ?? Icons.verified_outlined;
+
+    return FutureBuilder<PackageInfo>(
+      future: _packageInfoFuture,
+      builder: (context, snapshot) {
+        final textTheme = Theme.of(context).textTheme;
+        final subtitleStyle = textTheme.bodyMedium;
+
+        String subtitle;
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          subtitle = 'Загрузка…';
+        } else if (snapshot.hasError) {
+          subtitle = 'Недоступно';
+        } else if (snapshot.hasData) {
+          final info = snapshot.data!;
+          subtitle = '${info.version} (сборка ${info.buildNumber})';
+        } else {
+          subtitle = 'Недоступно';
+        }
+
+        return ListTile(
+          leading: Icon(leadingIcon),
+          title: const Text('Версия приложения'),
+          subtitle: Text(subtitle, style: subtitleStyle),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/circular_reveal_route.dart
+++ b/lib/widgets/circular_reveal_route.dart
@@ -1,0 +1,111 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Маршрут с анимацией радиального раскрытия (circular reveal).
+class CircularRevealPageRoute<T> extends PageRouteBuilder<T> {
+  CircularRevealPageRoute({
+    required WidgetBuilder builder,
+    required this.center,
+    Duration duration = const Duration(milliseconds: 520),
+    this.curve = Curves.easeOutCubic,
+    this.reverseCurve = Curves.easeInCubic,
+    RouteSettings? settings,
+  })  : super(
+          settings: settings,
+          transitionDuration: duration,
+          reverseTransitionDuration: duration,
+          pageBuilder: (context, animation, secondaryAnimation) =>
+              builder(context),
+        );
+  final Offset center;
+  final Curve curve;
+  final Curve reverseCurve;
+
+  static Offset originFromContext(BuildContext context) {
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox) {
+      return _centerOf(context);
+    }
+
+    final overlay = Navigator.of(context).overlay?.context.findRenderObject();
+    if (overlay is! RenderBox) {
+      return _centerOf(context);
+    }
+
+    return renderObject.localToGlobal(
+      renderObject.size.center(Offset.zero),
+      ancestor: overlay,
+    );
+  }
+
+  static Offset _centerOf(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    return Offset(size.width / 2, size.height / 2);
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    final curved = CurvedAnimation(
+      parent: animation,
+      curve: curve,
+      reverseCurve: reverseCurve,
+    );
+
+    return AnimatedBuilder(
+      animation: curved,
+      builder: (context, child) {
+        final size = MediaQuery.of(context).size;
+        return ClipPath(
+          clipper: _CircularRevealClipper(
+            progress: curved.value,
+            center: center,
+            size: size,
+          ),
+          child: child,
+        );
+      },
+      child: child,
+    );
+  }
+}
+
+class _CircularRevealClipper extends CustomClipper<Path> {
+  _CircularRevealClipper({
+    required this.progress,
+    required this.center,
+    required this.size,
+  });
+
+  final double progress;
+  final Offset center;
+  final Size size;
+
+  @override
+  Path getClip(Size clipSize) {
+    final radius = _maxRadius(size, center) * progress;
+    return Path()..addOval(Rect.fromCircle(center: center, radius: radius));
+  }
+
+  @override
+  bool shouldReclip(_CircularRevealClipper oldClipper) {
+    return oldClipper.progress != progress ||
+        oldClipper.center != center ||
+        oldClipper.size != size;
+  }
+
+  static double _maxRadius(Size size, Offset center) {
+    final distances = <double>[
+      (center - const Offset(0, 0)).distance,
+      (center - Offset(size.width, 0)).distance,
+      (center - Offset(0, size.height)).distance,
+      (center - Offset(size.width, size.height)).distance,
+    ];
+    return distances.reduce(math.max);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   shared_preferences: ^2.2.3
   webview_flutter: ^4.7.0
   share_plus: ^10.1.2
+  package_info_plus: ^7.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- surface the current app version and build number in Settings and the About screen via a reusable list tile
- introduce a reusable circular reveal page route and hook it up to the add contact/add note flows and the main screen reminders button
- rename the home screen title to "Touch NoteBook" to match the updated branding and add package_info_plus dependency

## Testing
- not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e6222f45fc8328ba1e6dc958ed0dd5