### PR TITLE
Add phone dialer permission handling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,4 +60,5 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
 </manifest>

--- a/android/app/src/main/kotlin/com/sergeyfierce/touchnotebookbeta_flutter/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/sergeyfierce/touchnotebookbeta_flutter/MainActivity.kt
@@ -1,5 +1,63 @@
 package com.sergeyfierce.touchnotebookbeta_flutter
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity(), ActivityCompat.OnRequestPermissionsResultCallback {
+
+    companion object {
+        private const val CHANNEL = "com.touchnotebookbeta/phone_permission"
+        private const val REQUEST_PHONE_PERMISSION = 2001
+    }
+
+    private var permissionResult: MethodChannel.Result? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "requestPermission" -> handlePhonePermission(result)
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun handlePhonePermission(result: MethodChannel.Result) {
+        if (permissionResult != null) {
+            result.error("PERMISSION_IN_PROGRESS", "Permission request is already running", null)
+            return
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            result.success(true)
+            return
+        }
+
+        val permissionState = ContextCompat.checkSelfPermission(this, Manifest.permission.CALL_PHONE)
+        if (permissionState == PackageManager.PERMISSION_GRANTED) {
+            result.success(true)
+            return
+        }
+
+        permissionResult = result
+        ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.CALL_PHONE), REQUEST_PHONE_PERMISSION)
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+
+        if (requestCode != REQUEST_PHONE_PERMISSION) {
+            return
+        }
+
+        val granted = grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED
+        permissionResult?.success(granted)
+        permissionResult = null
+    }
+}

--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -32,6 +33,8 @@ class ContactDetailsScreen extends StatefulWidget {
 enum _ReminderAction { complete, edit, delete }
 
 class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteAware {
+  static const MethodChannel _phonePermissionChannel =
+      MethodChannel('com.touchnotebookbeta/phone_permission');
   bool _isEditing = false;          // режим редактирования
   late Contact _contact;            // последний сохранённый снимок
 
@@ -747,12 +750,26 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
   }
 
   Future<void> _callContact() async {
-    final digits = _phoneController.text.replaceAll(RegExp(r'\D'), '');
+    final rawNumber = _phoneController.text.trim();
+    final digits = rawNumber.replaceAll(RegExp(r'\D'), '');
     if (digits.length < 11) {
       showErrorBanner('Введите корректный номер телефона');
       return;
     }
-    final uri = Uri(scheme: 'tel', path: digits);
+    var normalizedDigits = digits;
+    if (normalizedDigits.length == 11 && normalizedDigits.startsWith('8')) {
+      normalizedDigits = '7${normalizedDigits.substring(1)}';
+    }
+    final dialNumber = '+$normalizedDigits';
+
+    await Clipboard.setData(ClipboardData(text: dialNumber));
+    showSuccessBanner('Номер скопирован в буфер обмена');
+
+    if (!await _ensurePhonePermission()) {
+      return;
+    }
+
+    final uri = Uri(scheme: 'tel', path: dialNumber);
     try {
       if (!await canLaunchUrl(uri)) {
         showErrorBanner('Не удалось начать звонок');
@@ -761,6 +778,25 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     } catch (_) {
       showErrorBanner('Не удалось начать звонок');
+    }
+  }
+
+  Future<bool> _ensurePhonePermission() async {
+    if (!Platform.isAndroid) {
+      return true;
+    }
+
+    try {
+      final granted = await _phonePermissionChannel
+              .invokeMethod<bool>('requestPermission') ??
+          false;
+      if (!granted) {
+        showErrorBanner('Для звонка требуется разрешение на использование телефона');
+      }
+      return granted;
+    } on PlatformException {
+      showErrorBanner('Не удалось запросить разрешение на использование телефона');
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- copy the contact number, normalize it, and request phone permission before launching the system dialer
- add a platform channel to Android to prompt for the CALL_PHONE runtime permission and declare the manifest permission

## Testing
- Not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e633e59c6883288895f921fb93913b