### PR TITLE
Copy phone number to clipboard before launching dialer

### DIFF
--- a/lib/screens/contact_details_screen.dart
+++ b/lib/screens/contact_details_screen.dart
@@ -747,13 +747,15 @@ class _ContactDetailsScreenState extends State<ContactDetailsScreen> with RouteA
   }
 
   Future<void> _callContact() async {
-    final digits = _phoneController.text.replaceAll(RegExp(r'\D'), '');
+    final rawNumber = _phoneController.text.trim();
+    final digits = rawNumber.replaceAll(RegExp(r'\D'), '');
     if (digits.length < 11) {
       showErrorBanner('Введите корректный номер телефона');
       return;
     }
     final uri = Uri(scheme: 'tel', path: digits);
     try {
+      await Clipboard.setData(ClipboardData(text: rawNumber.isEmpty ? digits : rawNumber));
       if (!await canLaunchUrl(uri)) {
         showErrorBanner('Не удалось начать звонок');
         return;


### PR DESCRIPTION
## Summary
- copy the contact phone number to the clipboard before starting a call from the details screen
- continue to launch the system dialer with the sanitized number after copying

## Testing
- `flutter test` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e63682064083289ef46e71fda7a5e4