### PR TITLE
Add data encryption and expand test coverage

### DIFF
--- a/lib/services/encryption_service.dart
+++ b/lib/services/encryption_service.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:encrypt/encrypt.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+abstract class SecureKeyStorage {
+  const SecureKeyStorage();
+
+  Future<String?> read({required String key});
+
+  Future<void> write({required String key, required String value});
+}
+
+class FlutterSecureKeyStorage implements SecureKeyStorage {
+  const FlutterSecureKeyStorage();
+
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  @override
+  Future<String?> read({required String key}) => _storage.read(key: key);
+
+  @override
+  Future<void> write({required String key, required String value}) =>
+      _storage.write(key: key, value: value);
+}
+
+@visibleForTesting
+class InMemorySecureKeyStorage implements SecureKeyStorage {
+  InMemorySecureKeyStorage();
+
+  final Map<String, String> _store = <String, String>{};
+
+  @override
+  Future<String?> read({required String key}) async => _store[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _store[key] = value;
+  }
+}
+
+class EncryptionService {
+  EncryptionService._({SecureKeyStorage? storage})
+      : _storage = storage ?? const FlutterSecureKeyStorage();
+
+  factory EncryptionService.withStorage(SecureKeyStorage storage) =>
+      EncryptionService._(storage: storage);
+
+  static EncryptionService instance = EncryptionService._();
+
+  final SecureKeyStorage _storage;
+  final Random _random = _createSecureRandom();
+
+  static const String _storageKey = 'contact_db_master_key';
+  static const String encryptedPrefix = 'enc:';
+  static const String _separator = ':';
+
+  Key? _key;
+  Encrypter? _encrypter;
+
+  static Random _createSecureRandom() {
+    try {
+      return Random.secure();
+    } catch (_) {
+      return Random();
+    }
+  }
+
+  Future<void> ensureInitialized() async {
+    if (_encrypter != null && _key != null) return;
+
+    var storedKey = await _storage.read(key: _storageKey);
+    if (storedKey == null || storedKey.isEmpty) {
+      final keyBytes = Uint8List.fromList(
+        List<int>.generate(32, (_) => _random.nextInt(256)),
+      );
+      storedKey = base64Encode(keyBytes);
+      await _storage.write(key: _storageKey, value: storedKey);
+    }
+
+    _key = Key.fromBase64(storedKey);
+    _encrypter = Encrypter(AES(_key!, mode: AESMode.cbc));
+  }
+
+  bool isEncrypted(String value) => value.startsWith(encryptedPrefix);
+
+  String ensureEncrypted(String value) {
+    if (value.isEmpty) return value;
+    return isEncrypted(value) ? value : encrypt(value);
+  }
+
+  String ensureDecrypted(String value) {
+    if (value.isEmpty) return value;
+    return isEncrypted(value) ? decrypt(value) : value;
+  }
+
+  String encrypt(String value) {
+    if (value.isEmpty) return value;
+    final encrypter = _encrypter;
+    if (encrypter == null) {
+      throw StateError('EncryptionService has not been initialized');
+    }
+
+    final ivBytes = Uint8List.fromList(
+      List<int>.generate(16, (_) => _random.nextInt(256)),
+    );
+    final iv = IV(ivBytes);
+    final encrypted = encrypter.encrypt(value, iv: iv);
+    final payload = '${base64Encode(iv.bytes)}$_separator${encrypted.base64}';
+    return '$encryptedPrefix$payload';
+  }
+
+  String decrypt(String value) {
+    if (value.isEmpty) return value;
+    if (!isEncrypted(value)) return value;
+    final encrypter = _encrypter;
+    if (encrypter == null) {
+      throw StateError('EncryptionService has not been initialized');
+    }
+
+    final payload = value.substring(encryptedPrefix.length);
+    final parts = payload.split(_separator);
+    if (parts.length != 2) return value;
+
+    final iv = IV(base64Decode(parts[0]));
+    final encrypted = Encrypted.fromBase64(parts[1]);
+    return encrypter.decrypt(encrypted, iv: iv);
+  }
+
+  String hash(String value) {
+    final digest = sha256.convert(utf8.encode(value));
+    return digest.toString();
+  }
+
+  @visibleForTesting
+  static void resetForTests([EncryptionService? service]) {
+    instance = service ?? EncryptionService._();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,9 @@ dependencies:
   share_plus: ^10.1.2
   package_info_plus: ^9.0.0
   android_intent_plus: ^5.2.0
+  encrypt: ^5.0.3
+  flutter_secure_storage: ^9.0.0
+  crypto: ^3.0.3
 
 dev_dependencies:
   flutter_test:
@@ -37,6 +40,7 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   mocktail: ^1.0.1
   flutter_launcher_icons: ^0.13.1
+  sqflite_common_ffi: ^2.3.4
 
 flutter:
   uses-material-design: true

--- a/test/screens/add_contact_screen_test.dart
+++ b/test/screens/add_contact_screen_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:overlay_support/overlay_support.dart';
+
+import 'package:touchnotebookbeta_flutter/screens/add_contact_screen.dart';
+import 'package:touchnotebookbeta_flutter/services/contact_database.dart';
+import 'package:touchnotebookbeta_flutter/models/contact.dart';
+
+class MockContactDatabase extends Mock implements ContactDatabase {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockContactDatabase mockDb;
+  late ContactDatabase realDb;
+
+  setUp(() {
+    mockDb = MockContactDatabase();
+    realDb = ContactDatabase.instance;
+    ContactDatabase.instance = mockDb;
+
+    when(() => mockDb.contactByPhone(any(), excludeId: any(named: 'excludeId')))
+        .thenAnswer((_) async => null);
+    when(() => mockDb.contactByPhone(any())).thenAnswer((_) async => null);
+    when(() => mockDb.insert(any())).thenAnswer((_) async => 42);
+  });
+
+  tearDown(() {
+    ContactDatabase.instance = realDb;
+  });
+
+  testWidgets('saving a valid contact triggers insert and closes screen',
+      (tester) async {
+    await tester.pumpWidget(
+      OverlaySupport.global(
+        child: const MaterialApp(
+          home: AddContactScreen(category: 'Клиент'),
+        ),
+      ),
+    );
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'ФИО*'),
+      'Иван Иванов',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Телефон*'),
+      '9123456789',
+    );
+
+    await tester.tap(find.widgetWithText(TextFormField, 'Статус*'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Активный').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => mockDb.insert(
+        any(that: isA<Contact>().having((c) => c.phone, 'phone', '9123456789')),
+      ),
+    ).called(1);
+    expect(find.byType(AddContactScreen), findsNothing);
+  });
+}

--- a/test/screens/contact_details_screen_test.dart
+++ b/test/screens/contact_details_screen_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:overlay_support/overlay_support.dart';
+
+import 'package:touchnotebookbeta_flutter/models/contact.dart';
+import 'package:touchnotebookbeta_flutter/models/note.dart';
+import 'package:touchnotebookbeta_flutter/models/reminder.dart';
+import 'package:touchnotebookbeta_flutter/screens/contact_details_screen.dart';
+import 'package:touchnotebookbeta_flutter/services/contact_database.dart';
+import 'package:touchnotebookbeta_flutter/services/push_notifications.dart';
+
+class MockContactDatabase extends Mock implements ContactDatabase {}
+
+class MockFlutterLocalNotificationsPlugin extends Mock
+    implements FlutterLocalNotificationsPlugin {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockContactDatabase mockDb;
+  late ContactDatabase realDb;
+  late MockFlutterLocalNotificationsPlugin mockPlugin;
+
+  final contact = Contact(
+    id: 1,
+    name: 'Иван Иванов',
+    phone: '1234567890',
+    category: 'Клиент',
+    status: 'Активный',
+    createdAt: DateTime(2024, 1, 1),
+  );
+
+  setUp(() {
+    mockDb = MockContactDatabase();
+    realDb = ContactDatabase.instance;
+    ContactDatabase.instance = mockDb;
+
+    mockPlugin = MockFlutterLocalNotificationsPlugin();
+    when(() => mockPlugin.cancel(any())).thenAnswer((_) async => true);
+    when(() => mockPlugin.cancelAll()).thenAnswer((_) async => true);
+    PushNotifications.resetForTests(plugin: mockPlugin);
+
+    when(() => mockDb.contactByPhone(any(), excludeId: any(named: 'excludeId')))
+        .thenAnswer((_) async => null);
+    when(() => mockDb.update(any())).thenAnswer((_) async => 1);
+    when(() => mockDb.deleteContactWithSnapshot(any())).thenAnswer(
+      (_) async => (notes: <Note>[], reminders: <Reminder>[]),
+    );
+    when(() => mockDb.completeDueRemindersForContact(any()))
+        .thenAnswer((_) async => []);
+    when(
+      () => mockDb.remindersByContact(
+        any(),
+        onlyActive: any(named: 'onlyActive'),
+        onlyCompleted: any(named: 'onlyCompleted'),
+      ),
+    ).thenAnswer((_) async => []);
+    when(() => mockDb.lastNotesByContact(any(), limit: any(named: 'limit')))
+        .thenAnswer((_) async => []);
+  });
+
+  tearDown(() {
+    ContactDatabase.instance = realDb;
+    PushNotifications.resetForTests();
+  });
+
+  testWidgets('editing contact updates database and closes screen',
+      (tester) async {
+    await tester.pumpWidget(
+      OverlaySupport.global(
+        child: MaterialApp(
+          home: ContactDetailsScreen(contact: contact),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'ФИО*'),
+      'Иван Петров',
+    );
+    await tester.pump();
+
+    final saveButton =
+        find.widgetWithText(FloatingActionButton, 'Сохранить');
+    expect(saveButton, findsOneWidget);
+
+    await tester.tap(saveButton);
+    await tester.pumpAndSettle();
+
+    verify(
+      () => mockDb.update(
+        any(that: isA<Contact>().having((c) => c.name, 'name', 'Иван Петров')),
+      ),
+    ).called(1);
+    expect(find.byType(ContactDetailsScreen), findsNothing);
+  });
+
+  testWidgets('delete contact calls database and pops screen', (tester) async {
+    await tester.pumpWidget(
+      OverlaySupport.global(
+        child: MaterialApp(
+          home: ContactDetailsScreen(contact: contact),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Удалить контакт'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Удалить'));
+    await tester.pumpAndSettle();
+
+    verify(() => mockDb.deleteContactWithSnapshot(contact.id!)).called(1);
+    expect(find.byType(ContactDetailsScreen), findsNothing);
+  });
+}

--- a/test/screens/contact_list_screen_test.dart
+++ b/test/screens/contact_list_screen_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:overlay_support/overlay_support.dart';
+
+import 'package:touchnotebookbeta_flutter/models/contact.dart';
+import 'package:touchnotebookbeta_flutter/screens/contact_list_screen.dart';
+import 'package:touchnotebookbeta_flutter/services/contact_database.dart';
+
+class MockContactDatabase extends Mock implements ContactDatabase {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockContactDatabase mockDb;
+  late ContactDatabase realDb;
+  late ValueNotifier<int> revision;
+
+  setUp(() {
+    mockDb = MockContactDatabase();
+    realDb = ContactDatabase.instance;
+    ContactDatabase.instance = mockDb;
+    revision = ValueNotifier<int>(0);
+
+    when(() => mockDb.revision).thenReturn(revision);
+    when(
+      () => mockDb.contactsByCategoryPaged(
+        any(),
+        limit: any(named: 'limit'),
+        offset: any(named: 'offset'),
+      ),
+    ).thenAnswer((_) async => [
+          Contact(
+            id: 1,
+            name: 'Иван Иванов',
+            phone: '1234567890',
+            category: 'Клиент',
+            status: 'Активный',
+            createdAt: DateTime(2024, 1, 1),
+          ),
+        ]);
+    when(() => mockDb.activeReminderCountByContactIds(any()))
+        .thenAnswer((_) async => {});
+  });
+
+  tearDown(() {
+    ContactDatabase.instance = realDb;
+  });
+
+  testWidgets('list screen shows contacts from database', (tester) async {
+    await tester.pumpWidget(
+      OverlaySupport.global(
+        child: const MaterialApp(
+          home: ContactListScreen(category: 'Клиент', title: 'Клиенты'),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Иван Иванов'), findsOneWidget);
+  });
+}

--- a/test/services/contact_database_test.dart
+++ b/test/services/contact_database_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:sqflite/sqflite.dart' as sqflite;
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:touchnotebookbeta_flutter/models/contact.dart';
+import 'package:touchnotebookbeta_flutter/models/note.dart';
+import 'package:touchnotebookbeta_flutter/models/reminder.dart';
+import 'package:touchnotebookbeta_flutter/services/contact_database.dart';
+import 'package:touchnotebookbeta_flutter/services/encryption_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late sqflite.DatabaseFactory originalFactory;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+  });
+
+  Future<void> _resetDatabase() async {
+    await ContactDatabase.instance.close();
+    final dbPath = await sqflite.getDatabasesPath();
+    final path = p.join(dbPath, 'contacts.db');
+    await sqflite.deleteDatabase(path);
+  }
+
+  setUp(() async {
+    originalFactory = sqflite.databaseFactory;
+    sqflite.databaseFactory = databaseFactoryFfi;
+    EncryptionService.resetForTests(
+      EncryptionService.withStorage(InMemorySecureKeyStorage()),
+    );
+    await _resetDatabase();
+  });
+
+  tearDown(() async {
+    await _resetDatabase();
+    sqflite.databaseFactory = originalFactory;
+    EncryptionService.resetForTests();
+  });
+
+  test('insert and retrieve contact encrypts sensitive data', () async {
+    final db = ContactDatabase.instance;
+    final contact = Contact(
+      name: 'Иван Иванов',
+      phone: '1234567890',
+      category: 'Клиент',
+      status: 'Активный',
+      tags: const ['VIP'],
+      createdAt: DateTime(2024, 1, 1),
+    );
+
+    final id = await db.insert(contact);
+    final loaded = await db.contactById(id);
+    expect(loaded, isNotNull);
+    expect(loaded!.name, contact.name);
+    expect(loaded.phone, contact.phone);
+
+    final rawDb = await db.database;
+    final rows = await rawDb.query('contacts', where: 'id = ?', whereArgs: [id]);
+    expect(rows, isNotEmpty);
+
+    final storedName = rows.first['name'];
+    expect(storedName, isA<String>());
+    expect(
+      (storedName as String).startsWith(EncryptionService.encryptedPrefix),
+      isTrue,
+    );
+    expect(
+      rows.first['phoneHash'],
+      EncryptionService.instance.hash(contact.phone),
+    );
+  });
+
+  test('notes and reminders text are encrypted at rest', () async {
+    final db = ContactDatabase.instance;
+    final contact = Contact(
+      name: 'Test User',
+      phone: '1112223333',
+      category: 'Клиент',
+      status: 'Активный',
+      createdAt: DateTime(2024, 1, 1),
+    );
+
+    final contactId = await db.insert(contact);
+    final noteId = await db.insertNote(
+      Note(
+        contactId: contactId,
+        text: 'Чувствительная заметка',
+        createdAt: DateTime(2024, 1, 2),
+      ),
+    );
+    final reminderId = await db.insertReminder(
+      Reminder(
+        contactId: contactId,
+        text: 'Позвонить',
+        remindAt: DateTime(2024, 1, 3),
+        createdAt: DateTime(2024, 1, 2),
+      ),
+    );
+
+    final notes = await db.notesByContact(contactId);
+    expect(notes.single.text, 'Чувствительная заметка');
+
+    final reminders = await db.remindersByContact(contactId);
+    expect(reminders.single.text, 'Позвонить');
+
+    final rawDb = await db.database;
+    final noteRows =
+        await rawDb.query('notes', where: 'id = ?', whereArgs: [noteId]);
+    expect(
+      (noteRows.single['text'] as String)
+          .startsWith(EncryptionService.encryptedPrefix),
+      isTrue,
+    );
+
+    final reminderRows =
+        await rawDb.query('reminders', where: 'id = ?', whereArgs: [reminderId]);
+    expect(
+      (reminderRows.single['text'] as String)
+          .startsWith(EncryptionService.encryptedPrefix),
+      isTrue,
+    );
+  });
+}

--- a/test/services/push_notifications_test.dart
+++ b/test/services/push_notifications_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:timezone/data/latest_all.dart' as tzdata;
+import 'package:timezone/timezone.dart' as tz;
+
+import 'package:touchnotebookbeta_flutter/services/push_notifications.dart';
+
+class MockFlutterLocalNotificationsPlugin extends Mock
+    implements FlutterLocalNotificationsPlugin {}
+
+class MockAndroidFlutterLocalNotificationsPlugin extends Mock
+    implements AndroidFlutterLocalNotificationsPlugin {}
+
+class MockIOSFlutterLocalNotificationsPlugin extends Mock
+    implements IOSFlutterLocalNotificationsPlugin {}
+
+class MockMacOSFlutterLocalNotificationsPlugin extends Mock
+    implements MacOSFlutterLocalNotificationsPlugin {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockFlutterLocalNotificationsPlugin plugin;
+  late MockAndroidFlutterLocalNotificationsPlugin androidPlugin;
+  late MockIOSFlutterLocalNotificationsPlugin iosPlugin;
+  late MockMacOSFlutterLocalNotificationsPlugin macPlugin;
+
+  setUpAll(() {
+    tzdata.initializeTimeZones();
+    registerFallbackValue(
+      const InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        iOS: DarwinInitializationSettings(),
+        macOS: DarwinInitializationSettings(),
+      ),
+    );
+    registerFallbackValue(const NotificationDetails());
+    registerFallbackValue(tz.TZDateTime.now(tz.UTC));
+  });
+
+  setUp(() {
+    plugin = MockFlutterLocalNotificationsPlugin();
+    androidPlugin = MockAndroidFlutterLocalNotificationsPlugin();
+    iosPlugin = MockIOSFlutterLocalNotificationsPlugin();
+    macPlugin = MockMacOSFlutterLocalNotificationsPlugin();
+
+    when(
+      () => plugin.initialize(
+        any(),
+        onDidReceiveNotificationResponse:
+            any(named: 'onDidReceiveNotificationResponse'),
+        onDidReceiveBackgroundNotificationResponse:
+            any(named: 'onDidReceiveBackgroundNotificationResponse'),
+      ),
+    ).thenAnswer((_) async => true);
+    when(() => plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>()).thenReturn(androidPlugin);
+    when(() => plugin.resolvePlatformSpecificImplementation<
+        IOSFlutterLocalNotificationsPlugin>()).thenReturn(iosPlugin);
+    when(() => plugin.resolvePlatformSpecificImplementation<
+        MacOSFlutterLocalNotificationsPlugin>()).thenReturn(macPlugin);
+    when(() => androidPlugin.requestNotificationsPermission())
+        .thenAnswer((_) async => true);
+    when(() => androidPlugin.requestExactAlarmsPermission())
+        .thenAnswer((_) async => true);
+    when(
+      () => iosPlugin.requestPermissions(
+        alert: any(named: 'alert'),
+        badge: any(named: 'badge'),
+        sound: any(named: 'sound'),
+      ),
+    ).thenAnswer((_) async => true);
+    when(
+      () => macPlugin.requestPermissions(
+        alert: any(named: 'alert'),
+        badge: any(named: 'badge'),
+        sound: any(named: 'sound'),
+      ),
+    ).thenAnswer((_) async => true);
+    when(
+      () => plugin.zonedSchedule(
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        androidScheduleMode: any(named: 'androidScheduleMode'),
+        uiLocalNotificationDateInterpretation:
+            any(named: 'uiLocalNotificationDateInterpretation'),
+        payload: any(named: 'payload'),
+        matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+      ),
+    ).thenAnswer((_) async {});
+    when(() => plugin.show(any(), any(), any(), any()))
+        .thenAnswer((_) async => true);
+
+    PushNotifications.resetForTests(plugin: plugin);
+    PushNotifications.debugOverrideTimezoneResolver(() async => 'UTC');
+  });
+
+  tearDown(() {
+    PushNotifications.resetForTests();
+  });
+
+  test('scheduleOneTime schedules notification when enabled', () async {
+    await PushNotifications.scheduleOneTime(
+      id: 1,
+      whenLocal: DateTime.now().add(const Duration(hours: 1)),
+      title: 'Заголовок',
+      body: 'Тело',
+    );
+
+    verify(
+      () => plugin.zonedSchedule(
+        1,
+        'Заголовок',
+        'Тело',
+        any(),
+        any(),
+        androidScheduleMode: any(named: 'androidScheduleMode'),
+        uiLocalNotificationDateInterpretation:
+            any(named: 'uiLocalNotificationDateInterpretation'),
+        payload: any(named: 'payload'),
+        matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+      ),
+    ).called(1);
+  });
+
+  test('scheduleOneTime does nothing when disabled', () async {
+    PushNotifications.setEnabled(false);
+
+    await PushNotifications.scheduleOneTime(
+      id: 2,
+      whenLocal: DateTime.now().add(const Duration(hours: 1)),
+      title: 'Заголовок',
+      body: 'Тело',
+    );
+
+    verifyNever(
+      () => plugin.zonedSchedule(
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        androidScheduleMode: any(named: 'androidScheduleMode'),
+        uiLocalNotificationDateInterpretation:
+            any(named: 'uiLocalNotificationDateInterpretation'),
+        payload: any(named: 'payload'),
+        matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+      ),
+    );
+  });
+
+  test('showNotification forwards to plugin when enabled', () async {
+    await PushNotifications.showNotification(
+      id: 7,
+      title: 'Привет',
+      body: 'Мир',
+    );
+
+    verify(() => plugin.show(7, 'Привет', 'Мир', any())).called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add an encryption service backed by secure storage with in-memory overrides for tests
- encrypt contact, note, and reminder records in the database, hash phone numbers for lookups, and migrate existing data
- extend push notification utilities with test hooks and add database, notification, and CRUD screen widget tests
- add required package dependencies for encryption and FFI-backed testing

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e6450347b083288673dd294cf75247